### PR TITLE
Test mp.telemetry.tracing.enabled

### DIFF
--- a/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
+++ b/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
@@ -255,7 +255,7 @@ Implementation libraries can set the library name using the following property:
 
 == Tracing Enablement
 
-By default, MicroProfile Telemetry tracing is off. In order to enable any of the tracing aspects, the configuration `mp.telemetry.tracing.enabled=true` 
+By default, MicroProfile Telemetry tracing is off. In order to enable any of the tracing aspects, the configuration `mp.telemetry.trace.enabled=true` 
 must be specified in any of the config sources available via MicroProfile Config. This property is read once when the application is starting. Any changes afterwards will not take effect unless the application is restarted.
 
 == MicroProfile OpenTracing

--- a/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
+++ b/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
@@ -255,7 +255,7 @@ Implementation libraries can set the library name using the following property:
 
 == Tracing Enablement
 
-By default, MicroProfile Telemetry tracing is off. In order to enable any of the tracing aspects, the configuration `mp.telemetry.trace.enabled=true` 
+By default, MicroProfile Telemetry tracing is off. In order to enable any of the tracing aspects, the configuration `mp.telemetry.tracing.enabled=true` 
 must be specified in any of the config sources available via MicroProfile Config. This property is read once when the application is starting. Any changes afterwards will not take effect unless the application is restarted.
 
 == MicroProfile OpenTracing

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
@@ -23,6 +23,7 @@ package org.eclipse.microprofile.telemetry.tracing.tck.cdi;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,9 @@ import jakarta.inject.Inject;
 class TracerTest {
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
+                        "META-INF/microprofile-config.properties");
     }
 
     @Inject

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
@@ -38,7 +38,7 @@ class TracerTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -50,7 +50,7 @@ class BaggageTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2016-2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.eclipse.microprofile.telemetry.tracing.tck.rest;
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.extension.annotations.WithSpan;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
+
+@ExtendWith(ArquillianExtension.class)
+class RestClientSpanDefaultTest {
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}"),
+                        "META-INF/microprofile-config.properties");
+    }
+
+    @ArquillianResource
+    URL url;
+    @Inject
+    InMemorySpanExporter spanExporter;
+    @Inject
+    @RestClient
+    SpanResourceClient client;
+
+    @BeforeEach
+    void setUp() {
+        spanExporter.reset();
+    }
+
+    @Test
+    void span() {
+        Response response = client.span();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanName() {
+        Response response = client.spanName("1");
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanNameQuery() {
+        Response response = client.spanNameQuery("1", "query");
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanError() {
+        // Can't use REST Client here due to org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper
+        WebTarget target = ClientBuilder.newClient().target(url.toString() + "span/error");
+        Response response = target.request().get();
+        Assertions.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanChild() {
+        Response response = client.spanChild();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanCurrent() {
+        Response response = client.spanCurrent();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanNew() {
+        Response response = client.spanNew();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @RequestScoped
+    @Path("/")
+    public static class SpanResource {
+        @Inject
+        SpanBean spanBean;
+        @Inject
+        Span span;
+        @Inject
+        Tracer tracer;
+
+        @GET
+        @Path("/span")
+        public Response span() {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/{name}")
+        public Response spanName(@PathParam(value = "name") String name, @QueryParam("query") String query) {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/error")
+        public Response spanError() {
+            return Response.serverError().build();
+        }
+
+        @GET
+        @Path("/span/child")
+        public Response spanChild() {
+            spanBean.spanChild();
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/current")
+        public Response spanCurrent() {
+            span.setAttribute("tck.current.key", "tck.current.value");
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/new")
+        public Response spanNew() {
+            Span span = tracer.spanBuilder("span.new")
+                    .setSpanKind(INTERNAL)
+                    .setParent(Context.current().with(this.span))
+                    .setAttribute("tck.new.key", "tck.new.value")
+                    .startSpan();
+
+            span.end();
+
+            return Response.ok().build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SpanBean {
+        @WithSpan
+        void spanChild() {
+
+        }
+    }
+
+    @RegisterRestClient(configKey = "client")
+    @Path("/")
+    public interface SpanResourceClient {
+        @GET
+        @Path("/span")
+        Response span();
+
+        @GET
+        @Path("/span/{name}")
+        Response spanName(@PathParam(value = "name") String name);
+
+        @GET
+        @Path("/span/{name}")
+        Response spanNameQuery(@PathParam(value = "name") String name, @QueryParam("query") String query);
+
+        @GET
+        @Path("/span/child")
+        Response spanChild();
+
+        @GET
+        @Path("/span/current")
+        Response spanCurrent();
+
+        @GET
+        @Path("/span/new")
+        Response spanNew();
+    }
+
+    @ApplicationPath("/")
+    public static class RestApplication extends Application {
+
+    }
+}

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2016-2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.eclipse.microprofile.telemetry.tracing.tck.rest;
+
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.extension.annotations.WithSpan;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
+
+@ExtendWith(ArquillianExtension.class)
+class RestClientSpanDisabledTest {
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}\n"
+                        + "mp.telemetry.tracing.enabled=false"),
+                        "META-INF/microprofile-config.properties");
+    }
+
+    @ArquillianResource
+    URL url;
+    @Inject
+    InMemorySpanExporter spanExporter;
+    @Inject
+    @RestClient
+    SpanResourceClient client;
+
+    @BeforeEach
+    void setUp() {
+        spanExporter.reset();
+    }
+
+    @Test
+    void span() {
+        Response response = client.span();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanName() {
+        Response response = client.spanName("1");
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanNameQuery() {
+        Response response = client.spanNameQuery("1", "query");
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanError() {
+        // Can't use REST Client here due to org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper
+        WebTarget target = ClientBuilder.newClient().target(url.toString() + "span/error");
+        Response response = target.request().get();
+        Assertions.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanChild() {
+        Response response = client.spanChild();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanCurrent() {
+        Response response = client.spanCurrent();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanNew() {
+        Response response = client.spanNew();
+        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @RequestScoped
+    @Path("/")
+    public static class SpanResource {
+        @Inject
+        SpanBean spanBean;
+        @Inject
+        Span span;
+        @Inject
+        Tracer tracer;
+
+        @GET
+        @Path("/span")
+        public Response span() {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/{name}")
+        public Response spanName(@PathParam(value = "name") String name, @QueryParam("query") String query) {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/error")
+        public Response spanError() {
+            return Response.serverError().build();
+        }
+
+        @GET
+        @Path("/span/child")
+        public Response spanChild() {
+            spanBean.spanChild();
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/current")
+        public Response spanCurrent() {
+            span.setAttribute("tck.current.key", "tck.current.value");
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/span/new")
+        public Response spanNew() {
+            Span span = tracer.spanBuilder("span.new")
+                    .setSpanKind(INTERNAL)
+                    .setParent(Context.current().with(this.span))
+                    .setAttribute("tck.new.key", "tck.new.value")
+                    .startSpan();
+
+            span.end();
+
+            return Response.ok().build();
+        }
+    }
+
+    @ApplicationScoped
+    public static class SpanBean {
+        @WithSpan
+        void spanChild() {
+
+        }
+    }
+
+    @RegisterRestClient(configKey = "client")
+    @Path("/")
+    public interface SpanResourceClient {
+        @GET
+        @Path("/span")
+        Response span();
+
+        @GET
+        @Path("/span/{name}")
+        Response spanName(@PathParam(value = "name") String name);
+
+        @GET
+        @Path("/span/{name}")
+        Response spanNameQuery(@PathParam(value = "name") String name, @QueryParam("query") String query);
+
+        @GET
+        @Path("/span/child")
+        Response spanChild();
+
+        @GET
+        @Path("/span/current")
+        Response spanCurrent();
+
+        @GET
+        @Path("/span/new")
+        Response spanNew();
+    }
+
+    @ApplicationPath("/")
+    public static class RestApplication extends Application {
+
+    }
+}

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -63,7 +63,7 @@ class RestClientSpanDisabledTest {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}\n"
-                        + "mp.telemetry.tracing.enabled=false"),
+                        + "otel.experimental.sdk.enabled=false"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -75,7 +75,8 @@ class RestClientSpanTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}"),
+                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}\n"
+                        + "mp.telemetry.tracing.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -76,7 +76,7 @@ class RestClientSpanTest {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}\n"
-                        + "mp.telemetry.tracing.enabled=true"),
+                        + "otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -17,41 +17,38 @@
  * limitations under the License.
  *
  */
+
 package org.eclipse.microprofile.telemetry.tracing.tck.rest;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.opentelemetry.api.baggage.Baggage;
-import jakarta.inject.Inject;
+import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
 @ExtendWith(ArquillianExtension.class)
-class BaggageTest {
+class RestSpanDefaultTest {
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
-                        "META-INF/microprofile-config.properties");
+        return ShrinkWrap.create(WebArchive.class);
     }
 
     @ArquillianResource
@@ -65,22 +62,34 @@ class BaggageTest {
     }
 
     @Test
-    void baggage() {
-        WebTarget target = ClientBuilder.newClient().target(url.toString() + "baggage");
-        Response response = target.request().header("baggage", "user=naruto").get();
-        Assertions.assertEquals(HTTP_OK, response.getStatus());
-
-        spanExporter.getFinishedSpanItems(2);
+    void span() {
+        RestAssured.given().get("/span").then().statusCode(HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
     }
 
-    @Path("/baggage")
-    public static class BaggageResource {
-        @Inject
-        Baggage baggage;
+    @Test
+    void spanName() {
+        RestAssured.given().get("/span/1").then().statusCode(HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Test
+    void spanNameWithoutQueryString() {
+        RestAssured.given().get("/span/1?id=1").then().statusCode(HTTP_OK);
+        spanExporter.getFinishedSpanItems(0);
+    }
+
+    @Path("/")
+    public static class SpanResource {
+        @GET
+        @Path("/span")
+        public Response span() {
+            return Response.ok().build();
+        }
 
         @GET
-        public Response baggage() {
-            Assertions.assertEquals("naruto", baggage.getEntryValue("user"));
+        @Path("/span/{name}")
+        public Response spanName(@PathParam(value = "name") String name) {
             return Response.ok().build();
         }
     }

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -50,7 +50,7 @@ class RestSpanDisabledTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=false"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=false"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -62,7 +62,7 @@ class RestSpanTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/Java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -40,6 +40,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,9 @@ import jakarta.ws.rs.core.Response;
 class RestSpanTest {
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset("mp.telemetry.tracing.enabled=true"),
+                        "META-INF/microprofile-config.properties");
     }
 
     @ArquillianResource


### PR DESCRIPTION
Fixes https://github.com/eclipse/microprofile-telemetry/issues/29

Added tests for 
- `mp.telemetry.tracing.enabled` not set
- `mp.telemetry.tracing.enabled=true`
- `mp.telemetry.tracing.enabled=false`

Renamed `mp.telemetry.trace.enabled` to `mp.telemetry.tracing.enabled` in the spec

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>