### PR TITLE
Arquillian version updated

### DIFF
--- a/tracing/tck/pom.xml
+++ b/tracing/tck/pom.xml
@@ -23,8 +23,20 @@
     <artifactId>microprofile-telemetry-tracing-tck</artifactId>
     <name>MicroProfile Telemetry Tracing TCK</name>
 
+    <properties>
+        <!-- Overwriting Arquillian version from microprofile-tck-bom -->
+        <arquillian.version>1.7.0.Alpha12</arquillian.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile-tck-bom</artifactId>
@@ -40,7 +52,7 @@
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>     


### PR DESCRIPTION
PR for a MP Telemetry Tracing TCK local Arquillian update to 1.7.0.Alpha12.

Alternatively the update can be done in the microprofile-parent project ([PR is available](https://github.com/eclipse/microprofile-parent/pull/67)), but this would require a new release there and then updating the mircroprofile-tck-bom version here.

This PR is intended to fix TCK issues https://github.com/eclipse/microprofile-telemetry/issues/58 and https://github.com/eclipse/microprofile-telemetry/issues/53.