### PR TITLE
Move from Junit to TestNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 target/
 .vscode/
 *.DS_Store
+.project
+.classpath
+.settings
+.checkstyle
+bin/

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!--            <dependency>-->
-            <!--                    <groupId>io.opentelemetry</groupId>-->
-            <!--                    <artifactId>opentelemetry-api</artifactId>-->
-            <!--                    <version>${opentelemetry-api.version}</version>-->
-            <!--                    <scope>provided</scope>-->
-            <!--            </dependency>-->
-            <!-- This BOM includes the opentelemetry-bom and the opentelemetry-bom-alpha -->
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -35,7 +35,6 @@
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
         <version.microprofile-config-api>3.0.2</version.microprofile-config-api>
         <version.junit-jupiter>5.9.1</version.junit-jupiter>
-        <version.rest-assured>5.2.0</version.rest-assured>
         <version.awaitility>4.2.0</version.awaitility>
     </properties>
 

--- a/tracing/tck/pom.xml
+++ b/tracing/tck/pom.xml
@@ -85,12 +85,6 @@
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>${version.rest-assured}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${version.awaitility}</version>

--- a/tracing/tck/pom.xml
+++ b/tracing/tck/pom.xml
@@ -77,8 +77,12 @@
             <artifactId>opentelemetry-instrumentation-api-annotation-support</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-container</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -91,12 +95,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${version.junit-jupiter}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/BasicHttpClient.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/BasicHttpClient.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+
+/**
+ * A really basic client for doing Http requests
+ * <p>
+ * For use when we don't want to use JAX-RS client or something else which has integration with telemetry
+ */
+public class BasicHttpClient {
+
+    private URI baseUri;
+
+    /**
+     * @param baseUrl
+     *            The base URL. Any path requested through this client will be appended to this URL. This should usually
+     *            be a URL injected using {@link ArquillianResource}
+     */
+    public BasicHttpClient(URL baseUrl) {
+        try {
+            baseUri = baseUrl.toURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Makes a GET request to a path and returns the response code
+     * 
+     * @param path
+     *            the path to request, relative to the baseUrl
+     * @return the response code
+     */
+    public int get(String path) {
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        try {
+            URL spanUrl = baseUri.resolve(path).toURL();
+            HttpURLConnection connection = (HttpURLConnection) spanUrl.openConnection();
+            try {
+                return connection.getResponseCode();
+            } catch (Exception e) {
+                throw new RuntimeException("Exception retriving " + spanUrl, e);
+            } finally {
+                connection.disconnect();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Exception retriving path " + path, e);
+        }
+    }
+
+}

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/ConfigAsset.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/ConfigAsset.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+public class ConfigAsset implements Asset {
+
+    private Properties properties = new Properties();
+
+    @Override
+    public InputStream openStream() {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            properties.store(os, null);
+            return new ByteArrayInputStream(os.toByteArray());
+        } catch (IOException e) {
+            // Shouldn't happen since we're only using in memory streams
+            throw new RuntimeException("Unexpected error saving properties", e);
+        }
+    }
+
+    public ConfigAsset add(String key, String value) {
+        properties.put(key, value);
+        return this;
+    }
+
+}

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
@@ -41,7 +42,7 @@ import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-class TestApplication {
+class TestApplication extends Arquillian {
     @ArquillianResource
     private URL url;
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
@@ -24,13 +24,11 @@ import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -43,7 +41,6 @@ import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class TestApplication {
     @ArquillianResource
     private URL url;
@@ -59,7 +56,7 @@ class TestApplication {
         String uri = url.toExternalForm() + "rest";
         WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
         Response response = echoEndpointTarget.request(MediaType.TEXT_PLAIN).get();
-        Assertions.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
     }
 
     @ApplicationPath("/rest")

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestLibraries.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestLibraries.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+public class TestLibraries {
+
+    public static final JavaArchive AWAITILITY_LIB = ShrinkWrap.create(JavaArchive.class, "awaitility.jar")
+            .addPackages(true, "org.awaitility", "org.hamcrest");
+
+    private TestLibraries() {
+    }
+}

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
@@ -21,6 +21,7 @@
 package org.eclipse.microprofile.telemetry.tracing.tck.cdi;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -31,10 +32,12 @@ import io.opentelemetry.api.trace.Tracer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-class TracerTest {
+class TracerTest extends Arquillian {
+
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
+                .addClasses(TracerBean.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
@@ -21,19 +21,16 @@
 package org.eclipse.microprofile.telemetry.tracing.tck.cdi;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Tracer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-@ExtendWith(ArquillianExtension.class)
 class TracerTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -47,7 +44,7 @@ class TracerTest {
 
     @Test
     void tracer() {
-        Assertions.assertNotNull(tracerBean.getTracer());
+        Assert.assertNotNull(tracerBean.getTracer());
     }
 
     @ApplicationScoped

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
@@ -55,7 +55,7 @@ public class InMemorySpanExporter implements SpanExporter {
 
     public void assertSpanCount(int spanCount) {
         Awaitility.await().atMost(10, SECONDS)
-                .untilAsserted(() -> Assert.assertEquals(spanCount, finishedSpanItems.size()));
+                .untilAsserted(() -> Assert.assertEquals(finishedSpanItems.size(), spanCount));
     }
 
     public void reset() {

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
+import org.testng.Assert;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -55,7 +55,7 @@ public class InMemorySpanExporter implements SpanExporter {
 
     public void assertSpanCount(int spanCount) {
         Awaitility.await().atMost(10, SECONDS)
-                .untilAsserted(() -> Assertions.assertEquals(spanCount, finishedSpanItems.size()));
+                .untilAsserted(() -> Assert.assertEquals(spanCount, finishedSpanItems.size()));
     }
 
     public void reset() {

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
@@ -54,7 +54,7 @@ public class InMemorySpanExporter implements SpanExporter {
     }
 
     public void assertSpanCount(int spanCount) {
-        Awaitility.await().atMost(10, SECONDS)
+        Awaitility.await().pollDelay(3, SECONDS).atMost(10, SECONDS)
                 .untilAsserted(() -> Assert.assertEquals(finishedSpanItems.size(), spanCount));
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -25,15 +25,13 @@ import java.net.URL;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.api.baggage.Baggage;
 import jakarta.inject.Inject;
@@ -45,7 +43,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class BaggageTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -59,7 +56,7 @@ class BaggageTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }
@@ -68,7 +65,7 @@ class BaggageTest {
     void baggage() {
         WebTarget target = ClientBuilder.newClient().target(url.toString() + "baggage");
         Response response = target.request().header("baggage", "user=naruto").get();
-        Assertions.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(HTTP_OK, response.getStatus());
 
         spanExporter.getFinishedSpanItems(2);
     }
@@ -80,7 +77,7 @@ class BaggageTest {
 
         @GET
         public Response baggage() {
-            Assertions.assertEquals("naruto", baggage.getEntryValue("user"));
+            Assert.assertEquals("naruto", baggage.getEntryValue("user"));
             return Response.ok().build();
         }
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -72,7 +72,7 @@ class BaggageTest extends Arquillian {
 
     @Test
     void baggage() {
-        WebTarget target = ClientBuilder.newClient().target(url.toString() + "baggage");
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("baggage");
         Response response = target.request().header("baggage", "user=naruto").get();
         Assert.assertEquals(HTTP_OK, response.getStatus());
 
@@ -86,8 +86,15 @@ class BaggageTest extends Arquillian {
 
         @GET
         public Response baggage() {
-            Assert.assertEquals("naruto", baggage.getEntryValue("user"));
-            return Response.ok().build();
+            try {
+                Assert.assertEquals("naruto", baggage.getEntryValue("user"));
+                return Response.ok().build();
+            } catch (Throwable e) {
+                // An error here won't get reported back fully, so output it to the log as well
+                System.err.println("Baggage Resource Exception:");
+                e.printStackTrace();
+                throw e;
+            }
         }
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -54,7 +54,7 @@ class BaggageTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -24,6 +24,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import java.net.URL;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -35,6 +36,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
@@ -49,9 +51,7 @@ class BaggageTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -50,7 +50,7 @@ class BaggageTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -23,6 +23,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -52,6 +53,7 @@ class BaggageTest extends Arquillian {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.baggage.Baggage;
@@ -56,7 +56,7 @@ class BaggageTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/BaggageTest.java
@@ -74,7 +74,7 @@ class BaggageTest extends Arquillian {
     void baggage() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("baggage");
         Response response = target.request().header("baggage", "user=naruto").get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         spanExporter.getFinishedSpanItems(2);
     }
@@ -87,7 +87,7 @@ class BaggageTest extends Arquillian {
         @GET
         public Response baggage() {
             try {
-                Assert.assertEquals("naruto", baggage.getEntryValue("user"));
+                Assert.assertEquals(baggage.getEntryValue("user"), "naruto");
                 return Response.ok().build();
             } catch (Throwable e) {
                 // An error here won't get reported back fully, so output it to the log as well

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -43,6 +44,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -61,9 +63,7 @@ class RestClientSpanDefaultTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -30,15 +30,13 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -57,7 +55,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestClientSpanDefaultTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -74,7 +71,7 @@ class RestClientSpanDefaultTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }
@@ -82,21 +79,21 @@ class RestClientSpanDefaultTest {
     @Test
     void span() {
         Response response = client.span();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanName() {
         Response response = client.spanName("1");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNameQuery() {
         Response response = client.spanNameQuery("1", "query");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -105,28 +102,28 @@ class RestClientSpanDefaultTest {
         // Can't use REST Client here due to org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper
         WebTarget target = ClientBuilder.newClient().target(url.toString() + "span/error");
         Response response = target.request().get();
-        Assertions.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
+        Assert.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanChild() {
         Response response = client.spanChild();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanCurrent() {
         Response response = client.spanCurrent();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNew() {
         Response response = client.spanNew();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -47,7 +47,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -84,16 +83,13 @@ class RestClientSpanDefaultTest extends Arquillian {
         // Only want to run on server
         if (spanExporter != null) {
             spanExporter.reset();
-        }
-    }
-    
-    @PostConstruct
-    private void createClient() {
-        try {
-            // Create client manually so we can pass in URL from arquillian
-            client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
-        } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
-            Assert.fail("Failed to create rest client", e);
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
         }
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -68,7 +68,7 @@ class RestClientSpanDefaultTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
+                .addAsResource(new StringAsset("otel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,25 +56,34 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-class RestClientSpanDefaultTest {
+class RestClientSpanDefaultTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}"),
+                .addClasses(InMemorySpanExporter.class)
+                .addAsServiceProvider(
+                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
+                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 
     @ArquillianResource
     URL url;
+
     @Inject
     InMemorySpanExporter spanExporter;
+
     @Inject
     @RestClient
     SpanResourceClient client;
 
     @BeforeMethod
     void setUp() {
-        spanExporter.reset();
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+        }
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -35,7 +35,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
@@ -71,7 +71,7 @@ class RestClientSpanDefaultTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -64,7 +64,7 @@ class RestClientSpanDefaultTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -65,6 +66,7 @@ class RestClientSpanDefaultTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDefaultTest.java
@@ -68,7 +68,7 @@ class RestClientSpanDefaultTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -65,6 +66,7 @@ class RestClientSpanDisabledTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -35,7 +35,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
@@ -72,7 +72,7 @@ class RestClientSpanDisabledTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -68,7 +68,7 @@ class RestClientSpanDisabledTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -24,10 +24,12 @@ import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import java.net.URISyntaxException;
 import java.net.URL;
 
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -45,6 +47,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -73,8 +76,7 @@ class RestClientSpanDisabledTest extends Arquillian {
 
     @Inject
     InMemorySpanExporter spanExporter;
-    @Inject
-    @RestClient
+
     SpanResourceClient client;
 
     @BeforeMethod
@@ -82,6 +84,16 @@ class RestClientSpanDisabledTest extends Arquillian {
         // Only want to run on server
         if (spanExporter != null) {
             spanExporter.reset();
+        }
+    }
+    
+    @PostConstruct
+    private void createClient() {
+        try {
+            // Create client manually so we can pass in URL from arquillian
+            client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+        } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+            Assert.fail("Failed to create rest client", e);
         }
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -47,7 +47,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -84,16 +83,13 @@ class RestClientSpanDisabledTest extends Arquillian {
         // Only want to run on server
         if (spanExporter != null) {
             spanExporter.reset();
-        }
-    }
-    
-    @PostConstruct
-    private void createClient() {
-        try {
-            // Create client manually so we can pass in URL from arquillian
-            client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
-        } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
-            Assert.fail("Failed to create rest client", e);
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
         }
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -68,7 +68,7 @@ class RestClientSpanDisabledTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=false\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -64,7 +64,7 @@ class RestClientSpanDisabledTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -30,15 +30,13 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -57,7 +55,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestClientSpanDisabledTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -75,7 +72,7 @@ class RestClientSpanDisabledTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }
@@ -83,21 +80,21 @@ class RestClientSpanDisabledTest {
     @Test
     void span() {
         Response response = client.span();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanName() {
         Response response = client.spanName("1");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNameQuery() {
         Response response = client.spanNameQuery("1", "query");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -106,28 +103,28 @@ class RestClientSpanDisabledTest {
         // Can't use REST Client here due to org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper
         WebTarget target = ClientBuilder.newClient().target(url.toString() + "span/error");
         Response response = target.request().get();
-        Assertions.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
+        Assert.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanChild() {
         Response response = client.spanChild();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanCurrent() {
         Response response = client.spanCurrent();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNew() {
         Response response = client.spanNew();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanDisabledTest.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -43,6 +44,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -61,9 +63,7 @@ class RestClientSpanDisabledTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -42,6 +42,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -68,12 +69,15 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-class RestClientSpanTest {
+class RestClientSpanTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("client/mp-rest/url=${baseUri}\n"
-                        + "otel.experimental.sdk.enabled=true"),
+                .addClasses(InMemorySpanExporter.class)
+                .addAsServiceProvider(
+                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
+                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 
@@ -87,7 +91,10 @@ class RestClientSpanTest {
 
     @BeforeMethod
     void setUp() {
-        spanExporter.reset();
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+        }
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -54,6 +55,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
@@ -74,9 +76,7 @@ class RestClientSpanTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -41,15 +41,13 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -70,7 +68,6 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestClientSpanTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -88,7 +85,7 @@ class RestClientSpanTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }
@@ -96,85 +93,85 @@ class RestClientSpanTest {
     @Test
     void span() {
         Response response = client.span();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
     void spanName() {
         Response response = client.spanName("1");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/{name}", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/1", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/{name}", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/1", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/1", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/1", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(server.getTraceId(), client.getTraceId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(server.getTraceId(), client.getTraceId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
     void spanNameQuery() {
         Response response = client.spanNameQuery("1", "query");
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/{name}", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/1?query=query", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/{name}", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/1?query=query", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/1?query=query", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/1?query=query", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
@@ -182,127 +179,127 @@ class RestClientSpanTest {
         // Can't use REST Client here due to org.jboss.resteasy.microprofile.client.DefaultResponseExceptionMapper
         WebTarget target = ClientBuilder.newClient().target(url.toString() + "span/error");
         Response response = target.request().get();
-        Assertions.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
+        Assert.assertEquals(response.getStatus(), HTTP_INTERNAL_ERROR);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/error", server.getName());
-        Assertions.assertEquals(HTTP_INTERNAL_ERROR, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/error", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/error", server.getName());
+        Assert.assertEquals(HTTP_INTERNAL_ERROR, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/error", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(1);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_INTERNAL_ERROR, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/error", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_INTERNAL_ERROR, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/error", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
     void spanChild() {
         Response response = client.spanChild();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         SpanData internal = spans.get(0);
-        Assertions.assertEquals(INTERNAL, internal.getKind());
-        Assertions.assertEquals("SpanBean.spanChild", internal.getName());
+        Assert.assertEquals(INTERNAL, internal.getKind());
+        Assert.assertEquals("SpanBean.spanChild", internal.getName());
 
         SpanData server = spans.get(1);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/child", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/child", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/child", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/child", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(2);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/child", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/child", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), internal.getTraceId());
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(internal.getParentSpanId(), server.getSpanId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), internal.getTraceId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(internal.getParentSpanId(), server.getSpanId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
     void spanCurrent() {
         Response response = client.spanCurrent();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/current", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/current", server.getAttributes().get(HTTP_TARGET));
-        Assertions.assertEquals("tck.current.value", server.getAttributes().get(stringKey("tck.current.key")));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/current", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/current", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals("tck.current.value", server.getAttributes().get(stringKey("tck.current.key")));
 
         SpanData client = spans.get(1);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/current", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/current", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @Test
     void spanNew() {
         Response response = client.spanNew();
-        Assertions.assertEquals(response.getStatus(), HTTP_OK);
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         SpanData internal = spans.get(0);
-        Assertions.assertEquals(INTERNAL, internal.getKind());
-        Assertions.assertEquals("span.new", internal.getName());
-        Assertions.assertEquals("tck.new.value", internal.getAttributes().get(stringKey("tck.new.key")));
+        Assert.assertEquals(INTERNAL, internal.getKind());
+        Assert.assertEquals("span.new", internal.getName());
+        Assert.assertEquals("tck.new.value", internal.getAttributes().get(stringKey("tck.new.key")));
 
         SpanData server = spans.get(1);
-        Assertions.assertEquals(SERVER, server.getKind());
-        Assertions.assertEquals(url.getPath() + "span/new", server.getName());
-        Assertions.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assertions.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assertions.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assertions.assertEquals(url.getPath() + "span/new", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(SERVER, server.getKind());
+        Assert.assertEquals(url.getPath() + "span/new", server.getName());
+        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
+        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
+        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
+        Assert.assertEquals(url.getPath() + "span/new", server.getAttributes().get(HTTP_TARGET));
 
         SpanData client = spans.get(2);
-        Assertions.assertEquals(CLIENT, client.getKind());
-        Assertions.assertEquals("HTTP GET", client.getName());
-        Assertions.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE));
-        Assertions.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assertions.assertEquals(url.toString() + "span/new", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(CLIENT, client.getKind());
+        Assert.assertEquals("HTTP GET", client.getName());
+        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
+        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
+        Assert.assertEquals(url.toString() + "span/new", client.getAttributes().get(HTTP_URL));
 
-        Assertions.assertEquals(client.getTraceId(), internal.getTraceId());
-        Assertions.assertEquals(client.getTraceId(), server.getTraceId());
-        Assertions.assertEquals(internal.getParentSpanId(), server.getSpanId());
-        Assertions.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(client.getTraceId(), internal.getTraceId());
+        Assert.assertEquals(client.getTraceId(), server.getTraceId());
+        Assert.assertEquals(internal.getParentSpanId(), server.getSpanId());
+        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
     }
 
     @RequestScoped

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -77,7 +77,7 @@ class RestClientSpanTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -46,7 +46,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.trace.Span;
@@ -85,7 +85,7 @@ class RestClientSpanTest {
     @RestClient
     SpanResourceClient client;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -113,21 +113,21 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span");
 
         SpanData client = spans.get(1);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span");
 
         Assert.assertEquals(client.getTraceId(), server.getTraceId());
         Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
@@ -141,21 +141,21 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/{name}", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/1", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), (url.getPath() + "span/{name}"));
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/1");
 
         SpanData client = spans.get(1);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/1", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/1");
 
         Assert.assertEquals(server.getTraceId(), client.getTraceId());
         Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
@@ -169,21 +169,21 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/{name}", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/1?query=query", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span/{name}");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/1?query=query");
 
         SpanData client = spans.get(1);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/1?query=query", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/1?query=query");
 
         Assert.assertEquals(client.getTraceId(), server.getTraceId());
         Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
@@ -199,21 +199,21 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/error", server.getName());
-        Assert.assertEquals(HTTP_INTERNAL_ERROR, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/error", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span/error");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_INTERNAL_ERROR);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/error");
 
         SpanData client = spans.get(1);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_INTERNAL_ERROR, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/error", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_INTERNAL_ERROR);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/error");
 
         Assert.assertEquals(client.getTraceId(), server.getTraceId());
         Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
@@ -227,30 +227,30 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         SpanData internal = spans.get(0);
-        Assert.assertEquals(INTERNAL, internal.getKind());
-        Assert.assertEquals("SpanBean.spanChild", internal.getName());
+        Assert.assertEquals(internal.getKind(), INTERNAL);
+        Assert.assertEquals(internal.getName(), "SpanBean.spanChild");
 
         SpanData server = spans.get(1);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/child", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/child", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span/child");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/child");
 
         SpanData client = spans.get(2);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/child", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/child");
 
-        Assert.assertEquals(client.getTraceId(), internal.getTraceId());
-        Assert.assertEquals(client.getTraceId(), server.getTraceId());
-        Assert.assertEquals(internal.getParentSpanId(), server.getSpanId());
-        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(internal.getTraceId(), client.getTraceId());
+        Assert.assertEquals(server.getTraceId(), client.getTraceId());
+        Assert.assertEquals(server.getSpanId(), internal.getParentSpanId());
+        Assert.assertEquals(client.getSpanId(), server.getParentSpanId());
     }
 
     @Test
@@ -261,25 +261,25 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(2);
 
         SpanData server = spans.get(0);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/current", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/current", server.getAttributes().get(HTTP_TARGET));
-        Assert.assertEquals("tck.current.value", server.getAttributes().get(stringKey("tck.current.key")));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span/current");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/current");
+        Assert.assertEquals(server.getAttributes().get(stringKey("tck.current.key")), "tck.current.value");
 
         SpanData client = spans.get(1);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/current", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/current");
 
-        Assert.assertEquals(client.getTraceId(), server.getTraceId());
-        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(server.getTraceId(), client.getTraceId());
+        Assert.assertEquals(client.getSpanId(), server.getParentSpanId());
     }
 
     @Test
@@ -290,31 +290,31 @@ class RestClientSpanTest extends Arquillian {
         List<SpanData> spans = spanExporter.getFinishedSpanItems(3);
 
         SpanData internal = spans.get(0);
-        Assert.assertEquals(INTERNAL, internal.getKind());
-        Assert.assertEquals("span.new", internal.getName());
-        Assert.assertEquals("tck.new.value", internal.getAttributes().get(stringKey("tck.new.key")));
+        Assert.assertEquals(internal.getKind(), INTERNAL);
+        Assert.assertEquals(internal.getName(), "span.new");
+        Assert.assertEquals(internal.getAttributes().get(stringKey("tck.new.key")), "tck.new.value");
 
         SpanData server = spans.get(1);
-        Assert.assertEquals(SERVER, server.getKind());
-        Assert.assertEquals(url.getPath() + "span/new", server.getName());
-        Assert.assertEquals(HTTP_OK, server.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, server.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals("http", server.getAttributes().get(HTTP_SCHEME));
-        Assert.assertEquals(url.getHost(), server.getAttributes().get(HTTP_SERVER_NAME));
-        Assert.assertEquals(url.getHost() + ":" + url.getPort(), server.getAttributes().get(HTTP_HOST));
-        Assert.assertEquals(url.getPath() + "span/new", server.getAttributes().get(HTTP_TARGET));
+        Assert.assertEquals(server.getKind(), SERVER);
+        Assert.assertEquals(server.getName(), url.getPath() + "span/new");
+        Assert.assertEquals(server.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(server.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(server.getAttributes().get(HTTP_SCHEME), "http");
+        Assert.assertEquals(server.getAttributes().get(HTTP_SERVER_NAME), url.getHost());
+        Assert.assertEquals(server.getAttributes().get(HTTP_HOST), url.getHost() + ":" + url.getPort());
+        Assert.assertEquals(server.getAttributes().get(HTTP_TARGET), url.getPath() + "span/new");
 
         SpanData client = spans.get(2);
-        Assert.assertEquals(CLIENT, client.getKind());
-        Assert.assertEquals("HTTP GET", client.getName());
-        Assert.assertEquals(HTTP_OK, client.getAttributes().get(HTTP_STATUS_CODE).intValue());
-        Assert.assertEquals(HttpMethod.GET, client.getAttributes().get(HTTP_METHOD));
-        Assert.assertEquals(url.toString() + "span/new", client.getAttributes().get(HTTP_URL));
+        Assert.assertEquals(client.getKind(), CLIENT);
+        Assert.assertEquals(client.getName(), "HTTP GET");
+        Assert.assertEquals(client.getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        Assert.assertEquals(client.getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        Assert.assertEquals(client.getAttributes().get(HTTP_URL), url.toString() + "span/new");
 
-        Assert.assertEquals(client.getTraceId(), internal.getTraceId());
-        Assert.assertEquals(client.getTraceId(), server.getTraceId());
-        Assert.assertEquals(internal.getParentSpanId(), server.getSpanId());
-        Assert.assertEquals(server.getParentSpanId(), client.getSpanId());
+        Assert.assertEquals(internal.getTraceId(), client.getTraceId());
+        Assert.assertEquals(server.getTraceId(), client.getTraceId());
+        Assert.assertEquals(server.getSpanId(), internal.getParentSpanId());
+        Assert.assertEquals(client.getSpanId(), server.getParentSpanId());
     }
 
     @RequestScoped

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -59,7 +59,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -96,16 +95,13 @@ class RestClientSpanTest extends Arquillian {
         // Only want to run on server
         if (spanExporter != null) {
             spanExporter.reset();
-        }
-    }
-    
-    @PostConstruct
-    private void createClient() {
-        try {
-            // Create client manually so we can pass in URL from arquillian
-            client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
-        } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
-            Assert.fail("Failed to create rest client", e);
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
         }
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -81,7 +81,7 @@ class RestClientSpanTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestClientSpanTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -78,6 +79,7 @@ class RestClientSpanTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -36,6 +37,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
@@ -50,9 +52,7 @@ class RestSpanDefaultTest extends Arquillian {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
                 .addPackages(true, io.restassured.RestAssured.class.getPackage())
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -29,7 +29,9 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -42,10 +44,17 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-class RestSpanDefaultTest {
+class RestSpanDefaultTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class);
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(InMemorySpanExporter.class)
+                .addPackages(true, io.restassured.RestAssured.class.getPackage())
+                .addAsServiceProvider(
+                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
+                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                        "META-INF/microprofile-config.properties");
     }
 
     @ArquillianResource
@@ -55,7 +64,10 @@ class RestSpanDefaultTest {
 
     @BeforeMethod
     void setUp() {
-        spanExporter.reset();
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+        }
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -55,7 +55,7 @@ class RestSpanDefaultTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -74,7 +74,7 @@ class RestSpanDefaultTest extends Arquillian {
     void span() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -82,7 +82,7 @@ class RestSpanDefaultTest extends Arquillian {
     void spanName() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -90,7 +90,7 @@ class RestSpanDefaultTest extends Arquillian {
     void spanNameWithoutQueryString() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -24,8 +24,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +37,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -31,7 +31,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.restassured.RestAssured;
@@ -53,7 +53,7 @@ class RestSpanDefaultTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -21,9 +21,11 @@
 package org.eclipse.microprofile.telemetry.tracing.tck.rest;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+import static org.testng.Assert.assertEquals;
 
 import java.net.URL;
 
+import org.eclipse.microprofile.telemetry.tracing.tck.BasicHttpClient;
 import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
@@ -33,7 +35,6 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -43,8 +44,6 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
@@ -52,7 +51,7 @@ class RestSpanDefaultTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, BasicHttpClient.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
@@ -64,35 +63,32 @@ class RestSpanDefaultTest extends Arquillian {
     @Inject
     InMemorySpanExporter spanExporter;
 
+    private BasicHttpClient basicClient;
+
     @BeforeMethod
     void setUp() {
         // Only want to run on server
         if (spanExporter != null) {
             spanExporter.reset();
+            basicClient = new BasicHttpClient(url);
         }
     }
 
     @Test
     void span() {
-        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
-        Response response = target.request().get();
-        Assert.assertEquals(response.getStatus(), HTTP_OK);
+        assertEquals(basicClient.get("/span"), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanName() {
-        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
-        Response response = target.request().get();
-        Assert.assertEquals(response.getStatus(), HTTP_OK);
+        assertEquals(basicClient.get("/span/1"), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNameWithoutQueryString() {
-        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
-        Response response = target.request().get();
-        Assert.assertEquals(response.getStatus(), HTTP_OK);
+        assertEquals(basicClient.get("/span/1?id=1"), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -51,7 +51,7 @@ class RestSpanDefaultTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -54,7 +54,7 @@ class RestSpanDefaultTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, BasicHttpClient.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
+                .addAsResource(new StringAsset("otel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -24,6 +24,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -52,6 +53,7 @@ class RestSpanDefaultTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -28,13 +28,11 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
@@ -44,7 +42,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestSpanDefaultTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -56,7 +53,7 @@ class RestSpanDefaultTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDefaultTest.java
@@ -34,15 +34,17 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
-import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
@@ -51,7 +53,6 @@ class RestSpanDefaultTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addPackages(true, io.restassured.RestAssured.class.getPackage())
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
@@ -72,19 +73,25 @@ class RestSpanDefaultTest extends Arquillian {
 
     @Test
     void span() {
-        RestAssured.given().get("/span").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanName() {
-        RestAssured.given().get("/span/1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNameWithoutQueryString() {
-        RestAssured.given().get("/span/1?id=1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -24,6 +24,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -52,6 +53,7 @@ class RestSpanDisabledTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -28,14 +28,12 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
@@ -45,7 +43,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestSpanDisabledTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -59,7 +56,7 @@ class RestSpanDisabledTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -54,7 +54,7 @@ class RestSpanDisabledTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, BasicHttpClient.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=false\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -43,11 +44,15 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-class RestSpanDisabledTest {
+class RestSpanDisabledTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=false"),
+                .addClasses(InMemorySpanExporter.class)
+                .addAsServiceProvider(
+                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
+                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
 
@@ -58,7 +63,10 @@ class RestSpanDisabledTest {
 
     @BeforeMethod
     void setUp() {
-        spanExporter.reset();
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+        }
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -74,7 +74,7 @@ class RestSpanDisabledTest extends Arquillian {
     void span() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -82,7 +82,7 @@ class RestSpanDisabledTest extends Arquillian {
     void spanName() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 
@@ -90,7 +90,7 @@ class RestSpanDisabledTest extends Arquillian {
     void spanNameWithoutQueryString() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -36,6 +37,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
@@ -49,9 +51,7 @@ class RestSpanDisabledTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -55,7 +55,7 @@ class RestSpanDisabledTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -24,8 +24,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URL;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -39,6 +37,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -51,7 +51,7 @@ class RestSpanDisabledTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -34,15 +34,17 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
-import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
@@ -71,19 +73,25 @@ class RestSpanDisabledTest extends Arquillian {
 
     @Test
     void span() {
-        RestAssured.given().get("/span").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanName() {
-        RestAssured.given().get("/span/1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 
     @Test
     void spanNameWithoutQueryString() {
-        RestAssured.given().get("/span/1?id=1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
         spanExporter.getFinishedSpanItems(0);
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanDisabledTest.java
@@ -32,7 +32,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.restassured.RestAssured;
@@ -56,7 +56,7 @@ class RestSpanDisabledTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -33,8 +33,6 @@ import static org.testng.Assert.assertNotNull;
 import java.net.URL;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -50,6 +48,7 @@ import org.testng.annotations.Test;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -63,7 +63,7 @@ class RestSpanTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(InMemorySpanExporter.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -67,7 +67,7 @@ class RestSpanTest extends Arquillian {
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
-                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
+                .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true\notel.traces.exporter=in-memory"),
                         "META-INF/microprofile-config.properties");
     }
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -116,7 +116,6 @@ class RestSpanTest extends Arquillian {
         InstrumentationScopeInfo libraryInfo = spanItems.get(0).getInstrumentationScopeInfo();
         // Was decided at the MP Call on 13/06/2022 that lib name and version are responsibility of lib implementations
         assertNotNull(libraryInfo.getName());
-        assertNotNull(libraryInfo.getVersion());
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -41,7 +41,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
@@ -68,7 +68,7 @@ class RestSpanTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeTest
+    @BeforeMethod
     void setUp() {
         spanExporter.reset();
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -27,8 +27,8 @@ import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.net.URL;
 import java.util.List;
@@ -37,14 +37,12 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -57,7 +55,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-@ExtendWith(ArquillianExtension.class)
 class RestSpanTest {
     @Deployment
     public static WebArchive createDeployment() {
@@ -71,7 +68,7 @@ class RestSpanTest {
     @Inject
     InMemorySpanExporter spanExporter;
 
-    @BeforeEach
+    @BeforeTest
     void setUp() {
         spanExporter.reset();
     }
@@ -84,7 +81,7 @@ class RestSpanTest {
         assertEquals(1, spanItems.size());
         assertEquals(SERVER, spanItems.get(0).getKind());
         assertEquals(url.getPath() + "span", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE));
+        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
         assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
 
         assertEquals("org/eclipse/microprofile/telemetry/tracing/tck",
@@ -106,7 +103,7 @@ class RestSpanTest {
         assertEquals(1, spanItems.size());
         assertEquals(SERVER, spanItems.get(0).getKind());
         assertEquals(url.getPath() + "span/{name}", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE));
+        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
         assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
     }
 
@@ -118,7 +115,7 @@ class RestSpanTest {
         assertEquals(1, spanItems.size());
         assertEquals(SERVER, spanItems.get(0).getKind());
         assertEquals(url.getPath() + "span/{name}", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE));
+        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
         assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
         assertEquals(url.getPath() + "span/1?id=1", spanItems.get(0).getAttributes().get(HTTP_TARGET));
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNotNull;
 import java.net.URL;
 import java.util.List;
 
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -64,6 +65,7 @@ class RestSpanTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.testng.Arquillian;
@@ -45,6 +46,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.restassured.RestAssured;
@@ -61,9 +63,7 @@ class RestSpanTest extends Arquillian {
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(InMemorySpanExporter.class)
-                .addAsServiceProvider(
-                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
-                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -55,10 +56,14 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
-class RestSpanTest {
+class RestSpanTest extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
+                .addClasses(InMemorySpanExporter.class)
+                .addAsServiceProvider(
+                        io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider.class,
+                        org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider.class)
                 .addAsResource(new StringAsset("otel.experimental.sdk.enabled=true"),
                         "META-INF/microprofile-config.properties");
     }
@@ -70,7 +75,10 @@ class RestSpanTest {
 
     @BeforeMethod
     void setUp() {
-        spanExporter.reset();
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+        }
     }
 
     @Test

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -86,18 +86,19 @@ class RestSpanTest extends Arquillian {
     void span() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals(1, spanItems.size());
-        assertEquals(SERVER, spanItems.get(0).getKind());
-        assertEquals(url.getPath() + "span", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
-        assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
+        assertEquals(spanItems.size(), 1);
+        assertEquals(spanItems.get(0).getKind(), SERVER);
+        assertEquals(spanItems.get(0).getName(), url.getPath() + "span");
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_METHOD), HttpMethod.GET);
 
-        assertEquals("org/eclipse/microprofile/telemetry/tracing/tck",
-                spanItems.get(0).getResource().getAttribute(SERVICE_NAME));
-        assertEquals("0.1.0-SNAPSHOT", spanItems.get(0).getResource().getAttribute(SERVICE_VERSION));
+        assertEquals(
+                spanItems.get(0).getResource().getAttribute(SERVICE_NAME),
+                "org/eclipse/microprofile/telemetry/tracing/tck");
+        assertEquals(spanItems.get(0).getResource().getAttribute(SERVICE_VERSION), "0.1.0-SNAPSHOT");
 
         InstrumentationScopeInfo libraryInfo = spanItems.get(0).getInstrumentationScopeInfo();
         // Was decided at the MP Call on 13/06/2022 that lib name and version are responsibility of lib implementations
@@ -109,29 +110,29 @@ class RestSpanTest extends Arquillian {
     void spanName() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals(1, spanItems.size());
-        assertEquals(SERVER, spanItems.get(0).getKind());
-        assertEquals(url.getPath() + "span/{name}", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
-        assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
+        assertEquals(spanItems.size(), 1);
+        assertEquals(spanItems.get(0).getKind(), SERVER);
+        assertEquals(spanItems.get(0).getName(), url.getPath() + "span/{name}");
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_METHOD), HttpMethod.GET);
     }
 
     @Test
     void spanNameWithoutQueryString() {
         WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
         Response response = target.request().get();
-        Assert.assertEquals(HTTP_OK, response.getStatus());
+        Assert.assertEquals(response.getStatus(), HTTP_OK);
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
-        assertEquals(1, spanItems.size());
-        assertEquals(SERVER, spanItems.get(0).getKind());
-        assertEquals(url.getPath() + "span/{name}", spanItems.get(0).getName());
-        assertEquals(HTTP_OK, spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue());
-        assertEquals(HttpMethod.GET, spanItems.get(0).getAttributes().get(HTTP_METHOD));
-        assertEquals(url.getPath() + "span/1?id=1", spanItems.get(0).getAttributes().get(HTTP_TARGET));
+        assertEquals(spanItems.size(), 1);
+        assertEquals(spanItems.get(0).getKind(), SERVER);
+        assertEquals(spanItems.get(0).getName(), url.getPath() + "span/{name}");
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_STATUS_CODE).intValue(), HTTP_OK);
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_METHOD), HttpMethod.GET);
+        assertEquals(spanItems.get(0).getAttributes().get(HTTP_TARGET), url.getPath() + "span/1?id=1");
     }
 
     @Path("/")

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/RestSpanTest.java
@@ -43,18 +43,20 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.restassured.RestAssured;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 
@@ -83,7 +85,9 @@ class RestSpanTest extends Arquillian {
 
     @Test
     void span() {
-        RestAssured.given().get("/span").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spanItems.size());
@@ -104,7 +108,9 @@ class RestSpanTest extends Arquillian {
 
     @Test
     void spanName() {
-        RestAssured.given().get("/span/1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spanItems.size());
@@ -116,7 +122,9 @@ class RestSpanTest extends Arquillian {
 
     @Test
     void spanNameWithoutQueryString() {
-        RestAssured.given().get("/span/1?id=1").then().statusCode(HTTP_OK);
+        WebTarget target = ClientBuilder.newClient().target(url.toString()).path("span/1").queryParam("id", "1");
+        Response response = target.request().get();
+        Assert.assertEquals(HTTP_OK, response.getStatus());
 
         List<SpanData> spanItems = spanExporter.getFinishedSpanItems(1);
         assertEquals(1, spanItems.size());

--- a/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,0 +1,1 @@
+org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider

--- a/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,1 +1,0 @@
-org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider

--- a/tracing/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tracing/tck/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,0 @@
-tck.ArquillianExtension


### PR DESCRIPTION
We have: 
- Enabled in-memory exporter in config
- Removed dependency on RestAssured
- Used arquillian URL for rest client tests
- Add InMemorySpanExporterProvider to test archive
- Add libraries and resource to test apps that need them
- Replaced javax Inject with jakarta Inject
- Fixup add awaitility to RestClientSpanDisabledTest
- Avoid using JAX-RS client in the Rest tests
- Set service name and version in config
- Removed test for optional instrumentation version value
- Corrected assert parameter order to actual, expected 