### PR TITLE
Remove unneeded TCK service file

### DIFF
--- a/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
+++ b/tracing/tck/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider
@@ -1,1 +1,0 @@
-org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider


### PR DESCRIPTION
This service file in the TCK jar isn't used. The service file that is used is packaged into the test application in the deployment method in each test.