### PR TITLE
Only mention the major.minor version on the spec doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,9 @@
 
     <properties>
         <inceptionYear>2022</inceptionYear>
+        <opentelemetry.spec.main.version>1.13</opentelemetry.spec.main.version>
         <opentelemetry.spec.version>1.13.0</opentelemetry.spec.version>
+        <opentelemetry.java.main.version>1.19</opentelemetry.java.main.version>
         <opentelemetry.java.version>1.19.0</opentelemetry.java.version>
         <version.microprofile.tck.bom>3.0</version.microprofile.tck.bom>
     </properties>
@@ -83,7 +85,9 @@
                     <configuration>
                         <attributes>
                             <otel-spec-version>${opentelemetry.spec.version}</otel-spec-version>
+                            <otel-spec-main-version>${opentelemetry.spec.main.version}</otel-spec-main-version>
                             <otel-java-version>${opentelemetry.java.version}</otel-java-version>
+                            <otel-java-main-version>${opentelemetry.java.spec.main.version}</otel-java-main-version>
                         </attributes>
                     </configuration>
                  </plugin>

--- a/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
+++ b/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
@@ -33,7 +33,10 @@ ifdef::backend-pdf[]
 endif::[]
 // Attributes defined in the microprofile-telemetry (parent) maven POM:
 //:otel-spec-version:
+//:otel-spec-main-version:
 //:otel-java-version:
+//:otel-java-main-version:
+
 
 // == License
 :sectnums!:

--- a/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
+++ b/tracing/spec/src/main/asciidoc/microprofile-telemetry-tracing-spec.asciidoc
@@ -57,7 +57,7 @@ https://opentelemetry.io[OpenTelemetry] is a set of APIs, SDKs, tooling and inte
 
 This specification defines the behaviors that allow MicroProfile applications to easily participate in an environment where distributed tracing is enabled via https://opentelemetry.io[OpenTelemetry] (a merger between https://opentracing.io[OpenTracing] and https://opencensus.io[OpenCensus]).
 
-This document and implementations *MUST* comply with the following OpenTelemetry {otel-spec-version} specifications:
+This document and implementations *MUST* comply with the following OpenTelemetry {otel-spec-main-version} specifications:
 
 * https://github.com/open-telemetry/opentelemetry-specification/blob/v{otel-spec-version}/specification/overview.md[OpenTelemetry Overview]
 * https://github.com/open-telemetry/opentelemetry-specification/blob/v{otel-spec-version}/specification/trace/api.md[Tracing API]
@@ -196,7 +196,7 @@ public class SpanResource {
 Implementations are free to support the OpenTelemetry Agent Instrumentation.
 This provides the ability to gather telemetry data without code modifications by attaching a Java Agent JAR to the running JVM.
 
-If an implementation of MicroProfile Telemetry Tracing provides such support, it must conform to the instructions detailed in the https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v{otel-java-version}[OpenTelemetry Java Instrumentation {otel-java-version}] project, including:
+If an implementation of MicroProfile Telemetry Tracing provides such support, it must conform to the instructions detailed in the https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v{otel-java-version}[OpenTelemetry Java Instrumentation {otel-java-main-version}] project, including:
 
 * https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/[Agent Configuration]
 * https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#suppressing-specific-auto-instrumentation[Suppressing Instrumentation]


### PR DESCRIPTION
Update the spec so that only major.minor of OTel version is mentioned so that the impls can pull in the micro version of OTel updates without the need to re-release the spec.