### PR TITLE
Update TCK to test for all required REST span properties

### DIFF
--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/TracerTest.java
@@ -58,5 +58,6 @@ class TracerTest extends Arquillian {
         public Tracer getTracer() {
             return tracer;
         }
+
     }
 }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/exporter/InMemorySpanExporter.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -81,5 +82,10 @@ public class InMemorySpanExporter implements SpanExporter {
         finishedSpanItems.clear();
         isStopped = true;
         return CompletableResultCode.ofSuccess();
+    }
+
+    public SpanData getFirst(SpanKind spanKind) {
+        return finishedSpanItems.stream().filter(span -> span.getKind() == spanKind).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No span found with kind " + spanKind));
     }
 }


### PR DESCRIPTION
This follows Semantic Conventions 1.19, verifying most of required and conditionally required arguments.

* Specific values of span name is not checked, rather absence of high-cardinality parts of requests
* `net.host.name` and `net.host.port` are required for server Rest spans
* `http.route` is required for server Rest spans (normally optional, but "is required when server framework has concept of route", which Jakarta Rest has)
* `net.peer.name` and `net.peer.host` are required for client Rest spans
* error status of span is required for certain 4xx and 5xx requests

Fixes #86, #44.

Timing-dependant selections of span were for now replaced with kind-related ones, which work fine for existing tests.