### PR TITLE
Add TCK tests for telemetry tracing

### DIFF
--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/OpenTelemetryBeanTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/cdi/OpenTelemetryBeanTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.eclipse.microprofile.telemetry.tracing.tck.cdi;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.inject.Inject;
+
+class OpenTelemetryBeanTest extends Arquillian {
+
+    private static final String SPAN_NAME = "MySpanName";
+    private static final String INVALID_SPAN_ID = "0000000000000000";
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsResource(new StringAsset("otel.sdk.disabled=false"),
+                        "META-INF/microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Test
+    void testOpenTelemetryBean() {
+        Assert.assertNotNull(openTelemetry);
+    }
+
+    @Test
+    void testSpanAndTracer() {
+        Tracer tracer = openTelemetry.getTracer("instrumentation-test", "1.0.0");
+        Assert.assertNotNull(tracer);
+        Span span = tracer.spanBuilder(SPAN_NAME).startSpan();
+        Assert.assertNotEquals(span.getSpanContext().getSpanId(), INVALID_SPAN_ID);
+    }
+}


### PR DESCRIPTION
For issue #89. Add tests for: 

- Use of an injected OpenTelemetry bean
- WithSpan annotation parameters