### PR TITLE
Add optional propagation tests

### DIFF
--- a/tracing/tck/README.adoc
+++ b/tracing/tck/README.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Contributors to the Eclipse Foundation
+// Copyright (c) 2022-2023 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -50,21 +50,39 @@ To enable the tests in your project you need to add the following dependency to 
 ----
 
 == Declaring the Tests to run
-You also need to specify which tests you want to run, e.g. create a file `tck-suite.xml` in your project which contains the following content:
+There are optional tests for the `B3` and `Jaeger` progagation formats. These tests are present in the `optional-tests` group but a MicroProfile-Telemetry implementation is not required to pass these tests in order to be considered a valid implementation. If you wish to disable them, you can exclude the group e.g. create a file `tck-suite.xml` in your project which contains the following content:
 
 [source, xml]
 ----
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="microprofile-opentracing-TCK" verbose="2" configfailurepolicy="continue" >
-
-    <test name="microprofile-telemetry 1.0 TCK">
+<suite name="microprofile-telemetry-tracing-TCK" verbose="2" configfailurepolicy="continue" >
+    <test name="telemetry-tracing-tests" verbose="10">
+        <groups>
+            <run>
+                <!-- Exclude B3 and Jaeger propagation tests-->
+                <exclude name="optional-tests"/>
+            </run>
+        </groups>
         <packages>
-            <package name="org.eclipse.microprofile.telemetry.tracing.tck.*">
-            </package>
+            <package name="org.eclipse.microprofile.telemetry.tracing.tck.*" />
         </packages>
     </test>
+</suite>
+----
 
+If you want to run the optional tests, you can specify all tests in the `tck-suite.xml`. E.g. 
+
+[source, xml]
+----
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-telemetry-tracing-TCK" verbose="2" configfailurepolicy="continue" >
+    <test name="telemetry-tracing-tests" verbose="10">
+        <packages>
+            <package name="org.eclipse.microprofile.telemetry.tracing.tck.*" />
+        </packages>
+    </test>
 </suite>
 ----
 

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3MultiPropagationTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3MultiPropagationTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck.rest;
+
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_KEY;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.PROPAGATION_HEADERS_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.SpanResourceClient;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+
+public class B3MultiPropagationTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, PropagationHelper.class,
+                        SpanResourceClient.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.propagators=b3multi"),
+                        "META-INF/microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @ArquillianResource
+    URL url;
+    @Inject
+    InMemorySpanExporter spanExporter;
+
+    SpanResourceClient client;
+
+    @BeforeMethod
+    void setUp() {
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
+        }
+    }
+
+    @Test(groups = "optional-tests")
+    void B3MultiPropagation() {
+
+        Baggage baggage = Baggage.builder()
+                .put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+        try (Scope s = baggage.makeCurrent()) {
+            client.span();
+        }
+        // assertResponseStatus(response, OK);
+
+        spanExporter.assertSpanCount(2);
+
+        SpanData server = spanExporter.getFirst(SpanKind.SERVER);
+
+        // B3 does not support baggage, so baggage should not be propagated
+        Assert.assertNull(server.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        Assert.assertNull(server.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-TraceId"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-SpanId"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("X-B3-Sampled"));
+    }
+}

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3PropagationTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/B3PropagationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck.rest;
+
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_KEY;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.SpanResourceClient;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+
+public class B3PropagationTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, PropagationHelper.class,
+                        SpanResourceClient.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.propagators=b3"),
+                        "META-INF/microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @ArquillianResource
+    URL url;
+    @Inject
+    InMemorySpanExporter spanExporter;
+
+    SpanResourceClient client;
+
+    @BeforeMethod
+    void setUp() {
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
+        }
+    }
+
+    @Test(groups = "optional-tests")
+    void B3Propagation() {
+
+        Baggage baggage = Baggage.builder()
+                .put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+        try (Scope s = baggage.makeCurrent()) {
+            client.span();
+        }
+        spanExporter.assertSpanCount(2);
+
+        SpanData server = spanExporter.getFirst(SpanKind.SERVER);
+
+        // B3 does not support baggage, so baggage should not be propagated
+        Assert.assertNull(server.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        Assert.assertNull(server.getAttributes().get(BAGGAGE_METADATA_ATTR));
+
+        // Assert that the expected headers were used
+        Assert.assertTrue(
+                server.getAttributes().get(AttributeKey.stringArrayKey("test.propagation.headers")).contains("b3"));
+
+    }
+}

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/JaegerPropagationTest.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/rest/JaegerPropagationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.telemetry.tracing.tck.rest;
+
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_KEY;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_METADATA_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.BAGGAGE_VALUE_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.PROPAGATION_HEADERS_ATTR;
+import static org.eclipse.microprofile.telemetry.tracing.tck.rest.PropagationHelper.SpanResourceClient;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.telemetry.tracing.tck.TestLibraries;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporter;
+import org.eclipse.microprofile.telemetry.tracing.tck.exporter.InMemorySpanExporterProvider;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import jakarta.inject.Inject;
+
+public class JaegerPropagationTest extends Arquillian {
+    @Deployment
+    public static WebArchive createDeployment() {
+
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(InMemorySpanExporter.class, InMemorySpanExporterProvider.class, PropagationHelper.class,
+                        SpanResourceClient.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporterProvider.class)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.traces.exporter=in-memory\notel.propagators=jaeger"),
+                        "META-INF/microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @ArquillianResource
+    URL url;
+    @Inject
+    InMemorySpanExporter spanExporter;
+
+    SpanResourceClient client;
+
+    @BeforeMethod
+    void setUp() {
+        // Only want to run on server
+        if (spanExporter != null) {
+            spanExporter.reset();
+
+            try {
+                // Create client manually so we can pass in URL from arquillian
+                client = RestClientBuilder.newBuilder().baseUri(url.toURI()).build(SpanResourceClient.class);
+            } catch (IllegalStateException | RestClientDefinitionException | URISyntaxException e) {
+                Assert.fail("Failed to create rest client", e);
+            }
+        }
+    }
+
+    @Test(groups = "optional-tests")
+    void JaegerPropagation() {
+
+        Baggage baggage = Baggage.builder()
+                .put(BAGGAGE_KEY, BAGGAGE_VALUE, BaggageEntryMetadata.create(BAGGAGE_METADATA)).build();
+        try (Scope s = baggage.makeCurrent()) {
+            client.span();
+        }
+
+        spanExporter.assertSpanCount(2);
+
+        SpanData server = spanExporter.getFirst(SpanKind.SERVER);
+
+        // assert baggage is propagated
+        Assert.assertEquals(BAGGAGE_VALUE, server.getAttributes().get(BAGGAGE_VALUE_ATTR));
+        // Jaeger does not propagate baggage metadata, so we get back the result of
+        // BaggageEntryMetadata.empty().getValue() which is an empty string.
+        Assert.assertEquals(server.getAttributes().get(BAGGAGE_METADATA_ATTR), "");
+
+        // assert that the expected headers were used
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("uber-trace-id"));
+        Assert.assertTrue(server.getAttributes().get(PROPAGATION_HEADERS_ATTR).contains("uberctx-" + BAGGAGE_KEY));
+    }
+}


### PR DESCRIPTION
For issue #89 
The b3 and jaeger propagation formats are not required. Tests have been added in the group "optional-tests". The other teats are also put in to groups and the ReadMe.adoc has been updated with instructions on including these 