### PR TITLE
Support use of arquillian REST protocol

### DIFF
--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/TestApplication.java
@@ -60,12 +60,12 @@ class TestApplication extends Arquillian {
         Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
     }
 
-    @ApplicationPath("/rest")
+    @ApplicationPath("/")
     public static class RestApplication extends Application {
 
     }
 
-    @Path("/")
+    @Path("/rest")
     public static class TestEndpoint {
         @Inject
         HelloBean helloBean;

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
@@ -29,15 +29,10 @@ import org.testng.Assert;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Scope;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
@@ -51,9 +46,6 @@ public class MpRestClientAsyncTestEndpoint extends Application {
 
     @Inject
     private InMemorySpanExporter spanExporter;
-
-    @Inject
-    private HttpServletRequest request;
 
     @GET
     @Path("/mpclient")


### PR DESCRIPTION
- Ensure that requests from the arquillian framework itself are ignored by the InMemorySpanExporter
- Remove reference to the servlet API
- Avoid using "/" path in a test application
  - The arquillian rest protocol includes a rest resource class with @Path("/"). Autodiscovery for the test application is also picking up the arquillian class. If the test application also has a resource method mapped to "/", the server will fail a request to that path.

Fixes #72 