### PR TITLE
Update to consume the MP parent pom 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>3.1</version>
+        <version>3.2</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.telemetry</groupId>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
-        <version.microprofile-config-api>3.0.3</version.microprofile-config-api>
+        <version.microprofile-config-api>3.1-RC2</version.microprofile-config-api>
         <version.awaitility>4.2.0</version.awaitility>
     </properties>
 

--- a/tracing/tck/pom.xml
+++ b/tracing/tck/pom.xml
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile-tck-bom</artifactId>
-                <version>3.0</version>
+                <version>3.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -47,8 +47,12 @@
             <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>     
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-core-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
Update to use the mp-parent 3.2 to consume the version of MP parent as well as depending on the latest MP Config 3.1-RC2.