### PR TITLE
Update to use the final release of mp config 3.1

### DIFF
--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
-        <version.microprofile-config-api>3.1-RC2</version.microprofile-config-api>
+        <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.2.0</version.awaitility>
     </properties>
 


### PR DESCRIPTION
This change will make the build unstable before MP Config 3.1 was pushed to maven central. 