### PR TITLE
Split Application and Endpoint declarations

### DIFF
--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsClientAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsClientAsyncTestEndpoint.java
@@ -181,7 +181,7 @@ public class JaxRsClientAsyncTestEndpoint {
     }
 
     @ApplicationPath("/")
-    public static class Application extends jakarta.ws.rs.core.Application {
+    public static class RestApplication extends Application {
 
     }
 }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsClientAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsClientAsyncTestEndpoint.java
@@ -49,9 +49,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-@ApplicationPath("/")
 @Path("JaxRsClientAsyncTestEndpoint")
-public class JaxRsClientAsyncTestEndpoint extends Application {
+public class JaxRsClientAsyncTestEndpoint {
 
     public static final String TEST_PASSED = "Test Passed";
 
@@ -181,4 +180,8 @@ public class JaxRsClientAsyncTestEndpoint extends Application {
         return Response.status(HTTP_BAD_REQUEST).build();
     }
 
+    @ApplicationPath("/")
+    public static class Application extends jakarta.ws.rs.core.Application {
+
+    }
 }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsServerAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsServerAsyncTestEndpoint.java
@@ -66,9 +66,8 @@ import jakarta.ws.rs.core.Response.Status;
  * </ul>
  *
  */
-@ApplicationPath("/")
 @Path("JaxRsServerAsyncTestEndpoint")
-public class JaxRsServerAsyncTestEndpoint extends Application {
+public class JaxRsServerAsyncTestEndpoint {
 
     public static final String BAGGAGE_KEY = "test.baggage.key";
     public static final AttributeKey<String> BAGGAGE_VALUE_ATTR = AttributeKey.stringKey("test.baggage");
@@ -78,11 +77,6 @@ public class JaxRsServerAsyncTestEndpoint extends Application {
 
     @Inject
     private Tracer tracer;
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(JaxRsServerAsyncTestEndpoint.class);
-    }
 
     @GET
     @Path("completionstage")
@@ -208,6 +202,15 @@ public class JaxRsServerAsyncTestEndpoint extends Application {
             throw new RuntimeException(e);
         } finally {
             span.end();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class RestApplication extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            return Collections.singleton(JaxRsServerAsyncTestEndpoint.class);
         }
     }
 }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
@@ -44,7 +44,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 @Path("MpRestClientAsyncTestEndpoint")
-public class MpRestClientAsyncTestEndpoint extends Application {
+public class MpRestClientAsyncTestEndpoint {
 
     public static final String TEST_PASSED = "Test Passed";
     public static final String TEST_VALUE = "TEST_VALUE";
@@ -209,7 +209,7 @@ public class MpRestClientAsyncTestEndpoint extends Application {
     }
 
     @ApplicationPath("/")
-    public static class Application extends jakarta.ws.rs.core.Application {
+    public static class RestApplication extends Application {
 
     }
 }

--- a/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
+++ b/tracing/tck/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/MpRestClientAsyncTestEndpoint.java
@@ -43,7 +43,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-@ApplicationPath("/")
 @Path("MpRestClientAsyncTestEndpoint")
 public class MpRestClientAsyncTestEndpoint extends Application {
 
@@ -206,6 +205,11 @@ public class MpRestClientAsyncTestEndpoint extends Application {
         @GET
         @Path("requestMpClientError")
         public CompletionStage<String> requestMpClientError(@QueryParam("value") String value);
+
+    }
+
+    @ApplicationPath("/")
+    public static class Application extends jakarta.ws.rs.core.Application {
 
     }
 }


### PR DESCRIPTION
To run the TCK properly with RESTEasy and Jetty, the `Application` and endpoints declaration must be separate.

I had a look into the specification and also on the TCK. I couldn't find any indication that such set up should work.