### PR TITLE
Update semantic convention requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
     <properties>
         <inceptionYear>2022</inceptionYear>
         <opentelemetry.java.version>1.32.0</opentelemetry.java.version>
-        <opentelemetry.semconv.version>1.24.0</opentelemetry.semconv.version>
+        <opentelemetry.semconv.version>1.2ť.0</opentelemetry.semconv.version>
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.2.1</version.awaitility>
-        <version.otel.semconv>1.23.1-alpha</version.otel.semconv>
+        <version.otel.semconv>1.25.0-alpha</version.otel.semconv>
     </properties>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <inceptionYear>2022</inceptionYear>
         <opentelemetry.java.version>1.32.0</opentelemetry.java.version>
+        <opentelemetry.semconv.version>1.24.0</opentelemetry.semconv.version>
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.2.1</version.awaitility>
@@ -86,6 +87,7 @@
                     <configuration>
                         <attributes>
                             <otel-java-version>${opentelemetry.java.version}</otel-java-version>
+                            <otel-semconv-version>${opentelemetry.semconv.version}</otel-semconv-version>
                         </attributes>
                     </configuration>
                  </plugin>

--- a/spec/src/main/asciidoc/microprofile-telemetry-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-telemetry-spec.asciidoc
@@ -33,7 +33,7 @@ ifdef::backend-pdf[]
 endif::[]
 // Attributes defined in the microprofile-telemetry (parent) maven POM:
 //:otel-java-version:
-
+//:otel-semconv-version:
 
 // == License
 :sectnums!:

--- a/spec/src/main/asciidoc/opentelemetry-apis.adoc
+++ b/spec/src/main/asciidoc/opentelemetry-apis.adoc
@@ -72,13 +72,3 @@ The above packages have dependencies on the following packages which MUST be sup
 === Tracing Annotations
 
 * https://www.javadoc.io/doc/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/latest/io/opentelemetry/instrumentation/annotations/package-summary.html[io.opentelemetry.instrumentation.annotations] (`WithSpan` and `SpanAttribute` only)
-
-=== Semantic Conventions Attributes
-
-[NOTE]
-====
-These packages are not stable and MAY be subject to breaking changes in future releases.
-====
-
-* https://www.javadoc.io/static/io.opentelemetry/opentelemetry-semconv/{otel-java-version}-alpha/io/opentelemetry/semconv/trace/attributes/package-summary.html[io.opentelemetry.semconv]
-* https://www.javadoc.io/static/io.opentelemetry/opentelemetry-semconv/{otel-java-version}-alpha/io/opentelemetry/semconv/resource/attributes/package-summary.html[io.opentelemetry.semconv.resource.attributes]

--- a/spec/src/main/asciidoc/tracing.adoc
+++ b/spec/src/main/asciidoc/tracing.adoc
@@ -170,11 +170,16 @@ Calling the OpenTelemetry API directly MUST work in the same way and yield the s
 
 [[sec:semantic-conventions]]
 === Trace Semantic Conventions
-The https://github.com/open-telemetry/opentelemetry-java/tree/v{otel-java-version}/semconv/src/main/java/io/opentelemetry/semconv[Trace Semantic Conventions] for Spans and Attributes MUST be followed by any compatible implementation.
+The https://github.com/open-telemetry/semantic-conventions/blob/v{otel-semconv-version}/docs/http/http-spans.md[Semantic Conventions for HTTP Spans]  MUST be followed by any compatible implementation.
 
-All attributes marked as `required` MUST be present in the context of the Span where they are defined.
+NOTE: This is a breaking change from MicroProfile Telemetry 1.1 due to stabilization of HTTP semantic conventions in OpenTelemetry.
+Changes to attributes are described in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/migration-guide.md[HTTP semantic convention stability migration guide].
+// Migration guide was not part of 1.24.0 release, so the link is to the main branch.
+
+Semantic Conventions distinguish several https://github.com/open-telemetry/semantic-conventions/blob/v{otel-semconv-version}/docs/general/attribute-requirement-level.md[Requirement Levels] for attributes.
+All Span attributes marked as `Required` and `Conditionally Required` MUST be present in the context of the Span where they are defined.
 Any other attribute is optional.
-Implementations can also add their own attributes.
+Implementations MAY also add their own attributes, or provide means of configuring `Opt-In` attribute emission.
 
 ==== MicroProfile Attributes
 Other MicroProfile specifications can add their own attributes under their own attribute name following the convention `mp.[specification short name].[attribute name]`.


### PR DESCRIPTION
Partially addresses #150.

* Refers to stable HTTP Span semantic conventions
* Refers to non-normative document describing the changes
* Refers to attribute requirement levels
* Removes API for semantic attributes from class requirements

The last one may be a bit surprising one, but due to following reasons:

* Semantic conventions jar is no longer part of either stable or alpha bom of java SDK
* The current standalone semconv artifact (1.23.1-alpha) currently contains mix of stable, deprecated and experimental attributes in very flat hierarchy making it a very fragile API
* It is also out of sync with latest semconv at this time due to various reasons explained in https://github.com/open-telemetry/semantic-conventions-java/issues/44

