### PR TITLE
Add logging exporter for all signals

### DIFF
--- a/spec/src/main/asciidoc/configuration.adoc
+++ b/spec/src/main/asciidoc/configuration.adoc
@@ -41,21 +41,21 @@ Default value: `true`
 |`otel.traces.exporter`
 | List of exporters to be used for tracing, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `console` might link:#sec:service-loader-support[require additional libraries]. Implementations of the `otlp` and `console` exporters MUST be from the OpenTelemetry SDK.
 
 Default value: `otlp`
 
 |`otel.metrics.exporter`
 | List of exporters to be used for metrics, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `console` might link:#sec:service-loader-support[require additional libraries]. Implementations of the `otlp` and `console` exporters MUST be from the OpenTelemetry SDK.
 
 Default value: `otlp`
 
 |`otel.logs.exporter`
 | List of exporters to be used for logs, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `console` might link:#sec:service-loader-support[require additional libraries]. Implementations of the `otlp` and `console` exporters MUST be from the OpenTelemetry SDK.
 
 Default value: `otlp`
 

--- a/spec/src/main/asciidoc/configuration.adoc
+++ b/spec/src/main/asciidoc/configuration.adoc
@@ -41,21 +41,21 @@ Default value: `true`
 |`otel.traces.exporter`
 | List of exporters to be used for tracing, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none` and `otlp` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
 
 Default value: `otlp`
 
 |`otel.metrics.exporter`
 | List of exporters to be used for metrics, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none` and `otlp` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
 
 Default value: `otlp`
 
 |`otel.logs.exporter`
 | List of exporters to be used for logs, separated by commas.
 `none` means no autoconfigured exporter.
-Values other than `none` and `otlp` might link:#sec:service-loader-support[require additional libraries]
+Values other than `none`, `otlp` or `logging` might link:#sec:service-loader-support[require additional libraries]
 
 Default value: `otlp`
 


### PR DESCRIPTION
Adding the requirement that implementations support the logging exporter as a value for `otel.logs.exporter`, `otel.metrics.exporter`, `otel.traces.exporter`.  This is for use by the TCK (to provide a way to direct data to go to logs for easy testing) and for use by end users that would be able to use it for diagnostic purposes (especially when first getting set up with OTel).