### PR TITLE
Update to current versions of OpenTelemetry SDK and semantic conventions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,14 @@
 
     <properties>
         <inceptionYear>2022</inceptionYear>
-        <opentelemetry.java.version>1.32.0</opentelemetry.java.version>
-        <opentelemetry.semconv.version>1.25.0</opentelemetry.semconv.version>
+        <opentelemetry.java.version>1.39.0</opentelemetry.java.version>
+        <opentelemetry.semconv.version>1.26.0</opentelemetry.semconv.version>
+        <opentelemetry.java.instrumentation.version>2.5.0</opentelemetry.java.instrumentation.version>
         <version.mp.rest.client>3.0.1</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.2.1</version.awaitility>
-        <version.otel.semconv>1.25.0-alpha</version.otel.semconv>
+        <!-- Telemetry refers only to Semantic Conversion specification, java artifact is only used in TCK -->
+        <version.otel.semconv-java>1.25.0-alpha</version.otel.semconv-java>
     </properties>
 
     <issueManagement>
@@ -64,16 +66,21 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.opentelemetry.instrumentation</groupId>
-                <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-                <version>${opentelemetry.java.version}-alpha</version>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.java.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+                <version>${opentelemetry.java.instrumentation.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
-                <version>${version.otel.semconv}</version>
+                <version>${version.otel.semconv-java}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -93,6 +100,7 @@
                         <attributes>
                             <otel-java-version>${opentelemetry.java.version}</otel-java-version>
                             <otel-semconv-version>${opentelemetry.semconv.version}</otel-semconv-version>
+                            <otel-instrumentation-version>${opentelemetry.java.instrumentation.version}</otel-instrumentation-version>
                         </attributes>
                     </configuration>
                  </plugin>

--- a/spec/src/main/asciidoc/opentelemetry-apis.adoc
+++ b/spec/src/main/asciidoc/opentelemetry-apis.adoc
@@ -71,4 +71,4 @@ The above packages have dependencies on the following packages which MUST be sup
 
 === Tracing Annotations
 
-* https://www.javadoc.io/doc/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/latest/io/opentelemetry/instrumentation/annotations/package-summary.html[io.opentelemetry.instrumentation.annotations] (`WithSpan` and `SpanAttribute` only)
+* https://www.javadoc.io/doc/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/{otel-instrumentation-version}/io/opentelemetry/instrumentation/annotations/package-summary.html[io.opentelemetry.instrumentation.annotations] (`WithSpan` and `SpanAttribute` only)

--- a/spec/src/main/asciidoc/tracing.adoc
+++ b/spec/src/main/asciidoc/tracing.adoc
@@ -173,8 +173,7 @@ Calling the OpenTelemetry API directly MUST work in the same way and yield the s
 The https://github.com/open-telemetry/semantic-conventions/blob/v{otel-semconv-version}/docs/http/http-spans.md[Semantic Conventions for HTTP Spans]  MUST be followed by any compatible implementation.
 
 NOTE: This is a breaking change from MicroProfile Telemetry 1.1 due to stabilization of HTTP semantic conventions in OpenTelemetry.
-Changes to attributes are described in https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/migration-guide.md[HTTP semantic convention stability migration guide].
-// Migration guide was not part of 1.24.0 release, so the link is to the main branch.
+Changes to attributes are described in https://github.com/open-telemetry/semantic-conventions/blob/v{otel-semconv-version}/docs/http/migration-guide.md[HTTP semantic convention stability migration guide].
 
 Semantic Conventions distinguish several https://github.com/open-telemetry/semantic-conventions/blob/v{otel-semconv-version}/docs/general/attribute-requirement-level.md[Requirement Levels] for attributes.
 All Span attributes marked as `Required` and `Conditionally Required` MUST be present in the context of the Span where they are defined.


### PR DESCRIPTION
Fixes #192 

As discussed on yesterday's call we'll upgrade reference versions of OpenTelemetry java and Semantic Conventions spec to latest releases.

Situation is little bit more complicated than straight version change because:

    instrumentation APIs went to version 2.0 past switch of semantic conventions
    Java artifact for Semantic Concentions 1.26.0 is not yet released

Therefore we now explicitly depend on the BOM of OpenTelemetry Java SDK, and on annotations of current latest release which is 2.5.0. This version is also used for javadoc link.