### PR TITLE
Remove optional jaxrs tests

### DIFF
--- a/tck/metrics/README.adoc
+++ b/tck/metrics/README.adoc
@@ -49,35 +49,7 @@ To enable the tests in your project you need to add the following dependency to 
 
 ----
 
-== Declaring the Tests to run
-There are multiple groups of optional tests. These include: 
-
-* `optional-tests`: `B3` and `Jaeger` progagation formats. 
-+
-These tests test the B3 and Jaeger propagation formats which are not required. If your implementation does not include support for these propagation formats, you should exclude the `optional-tests` group.
-
-* `optional-jaxrs-tests` JAX-RS server async programming models
-+
-Although support for JAX-RS server async programming models is not optional, these tests depend on Jakarta Concurrency because they use `ManagedExecutorService`.
-+
-If you are testing in an environment which does not provide Jakarta Concurrency, you should exclude the `optional-jaxrs-tests` group.
-
-Test groups can be excluded in the TestNG XML file. E.g. create a file `tck-suite.xml` in your project which contains the following content:
-
-[source, xml]
-----
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-
-<suite name="microprofile-telemetry-metrics-TCK" verbose="2" configfailurepolicy="continue" >
-    <test name="telemetry-metrics-tests" verbose="10">
-        <packages>
-            <package name="org.eclipse.microprofile.telemetry.metrics.tck.*" />
-        </packages>
-    </test>
-</suite>
-----
-
-If you want to run the optional tests, you can specify all tests in the `tck-suite.xml`. E.g. 
+If you want to run the metrics tests, you can specify all tests in the `tck-suite.xml`. E.g. 
 
 [source, xml]
 ----

--- a/tck/tracing/README.adoc
+++ b/tck/tracing/README.adoc
@@ -50,17 +50,11 @@ To enable the tests in your project you need to add the following dependency to 
 ----
 
 == Declaring the Tests to run
-There are multiple groups of optional tests. These include: 
+There is a group of optional tests. This includes: 
 
 * `optional-tests`: `B3` and `Jaeger` progagation formats. 
 +
 These tests test the B3 and Jaeger propagation formats which are not required. If your implementation does not include support for these propagation formats, you should exclude the `optional-tests` group.
-
-* `optional-jaxrs-tests` JAX-RS server async programming models
-+
-Although support for JAX-RS server async programming models is not optional, these tests require you to provide an executor. <<Executor, See the section on providing an executor>>
-+
-If you are testing in an environment which does not provide Jakarta Concurrency, you should exclude the `optional-jaxrs-tests` group.
 
 Test groups can be excluded in the TestNG XML file. E.g. create a file `tck-suite.xml` in your project which contains the following content:
 
@@ -74,8 +68,6 @@ Test groups can be excluded in the TestNG XML file. E.g. create a file `tck-suit
             <run>
                 <!-- Exclude B3 and Jaeger propagation tests-->
                 <exclude name="optional-tests"/>
-                <!-- Exclude JaxRS server async tests-->
-                <exclude name="optional-jaxrs-tests"/>
             </run>
         </groups>
         <packages>

--- a/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsServerAsyncTest.java
+++ b/tck/tracing/src/main/java/org/eclipse/microprofile/telemetry/tracing/tck/async/JaxRsServerAsyncTest.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.SpanKind;
@@ -94,22 +93,18 @@ public class JaxRsServerAsyncTest extends Arquillian {
         }
     }
 
-    @Test(groups = "optional-jaxrs-tests")
     public void testJaxRsServerAsyncCompletionStage() {
         doAsyncTest((client) -> client.getCompletionStage(QUERY_VALUE));
     }
 
-    @Test(groups = "optional-jaxrs-tests")
     public void testJaxRsServerAsyncCompletionStageError() {
         doErrorAsyncTest((client) -> client.getCompletionStageError(QUERY_VALUE));
     }
 
-    @Test(groups = "optional-jaxrs-tests")
     public void testJaxRsServerAsyncSuspend() {
         doAsyncTest((client) -> client.getSuspend(QUERY_VALUE));
     }
 
-    @Test(groups = "optional-jaxrs-tests")
     public void testJaxRsServerAsyncSuspendError() {
         doErrorAsyncTest((client) -> client.getSuspendError(QUERY_VALUE));
     }


### PR DESCRIPTION
The metrics TCK readme should not mention the optional Tracing tests.
The tracing TCK no longer depends on Jakarta Concurrency and the tests for those are no longer optional so details in the readme have been removed and the tests are no longer in the "optional-tests" group. 