### PR TITLE
Tail -f the log rather than wait than read

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <!-- Telemetry refers only to Semantic Conversion specification, java artifact is only used in TCK -->
         <version.otel.semconv-java>1.25.0-alpha</version.otel.semconv-java>
         <version.mp.parent>3.4</version.mp.parent>
+        <version.commons.io>2.16.1</version.commons.io>
     </properties>
 
     <issueManagement>

--- a/tck/metrics/pom.xml
+++ b/tck/metrics/pom.xml
@@ -86,6 +86,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/application/TestLibraries.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/application/TestLibraries.java
@@ -27,6 +27,9 @@ public class TestLibraries {
     public static final JavaArchive AWAITILITY_LIB = ShrinkWrap.create(JavaArchive.class, "awaitility.jar")
             .addPackages(true, "org.awaitility", "org.hamcrest");
 
+    public static final JavaArchive COMMONS_IO_LIB = ShrinkWrap.create(JavaArchive.class, "commons-io.jar")
+            .addPackages(true, "org.apache.commons");
+
     private TestLibraries() {
     }
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmClassesTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmClassesTest.java
@@ -23,12 +23,12 @@ package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -44,27 +44,27 @@ public class JvmClassesTest extends Arquillian {
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MetricsReader.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     void testClassLoadedMetrics() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.class.loaded", "Number of classes loaded since JVM start.", "{class}",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.class.loaded", "Number of classes loaded since JVM start.", "{class}",
+                MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testClassUnloadedMetrics() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.class.unloaded", "Number of classes unloaded since JVM start.",
-                        "{class}", MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.class.unloaded", "Number of classes unloaded since JVM start.",
+                "{class}", MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testClassCountMetrics() throws IOException {
-        Assert.assertTrue(MetricsReader.checkMessage("jvm.class.count", "Number of classes currently loaded.",
-                "{class}", MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.class.count", "Number of classes currently loaded.",
+                "{class}", MetricDataType.LONG_SUM.toString());
     }
 
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmCpuTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmCpuTest.java
@@ -23,12 +23,12 @@ package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -44,28 +44,29 @@ public class JvmCpuTest extends Arquillian {
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MetricsReader.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     void testCpuTimeMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.cpu.time", "CPU time used by the process as reported by the JVM.", "s",
-                        MetricDataType.DOUBLE_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.cpu.time", "CPU time used by the process as reported by the JVM.", "s",
+                MetricDataType.DOUBLE_SUM.toString());
     }
 
     @Test
     void testCpuCountMetric() throws IOException {
-        Assert.assertTrue(MetricsReader.checkMessage("jvm.cpu.count",
+        MetricsReader.assertLogMessage("jvm.cpu.count",
                 "Number of processors available to the Java virtual machine.", "{cpu}",
-                MetricDataType.LONG_SUM.toString()));
+                MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testCpuRecentUtilizationMetric() throws IOException {
-        Assert.assertTrue(MetricsReader.checkMessage("jvm.cpu.recent_utilization",
+        MetricsReader.assertLogMessage("jvm.cpu.recent_utilization",
                 "Recent CPU utilization for the process as reported by the JVM.", "1",
-                MetricDataType.DOUBLE_GAUGE.toString()));
+                MetricDataType.DOUBLE_GAUGE.toString());
     }
 
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
@@ -23,12 +23,12 @@ package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -44,14 +44,15 @@ public class JvmGarbageCollectionTest extends Arquillian {
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MetricsReader.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     void testGarbageCollectionCountMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.gc.duration", "Duration of JVM garbage collection actions.", "s",
-                        MetricDataType.HISTOGRAM.toString()));
+        MetricsReader.assertLogMessage("jvm.gc.duration", "Duration of JVM garbage collection actions.", "s",
+                MetricDataType.HISTOGRAM.toString());
     }
 
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmMemoryTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmMemoryTest.java
@@ -23,12 +23,12 @@ package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -44,37 +44,35 @@ public class JvmMemoryTest extends Arquillian {
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MetricsReader.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     void testJvmMemoryUsedMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.memory.used", "Measure of memory used.", "By",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.memory.used", "Measure of memory used.", "By",
+                MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testJvmMemoryCommittedMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.memory.committed", "Measure of memory committed.", "By",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.memory.committed", "Measure of memory committed.", "By",
+                MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testMemoryLimitMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.memory.limit", "Measure of max obtainable memory.", "By",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.memory.limit", "Measure of max obtainable memory.", "By",
+                MetricDataType.LONG_SUM.toString());
     }
 
     @Test
     void testMemoryUsedAfterLastGcMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.memory.used_after_last_gc",
-                        "Measure of memory used, as measured after the most recent garbage collection event on this pool.",
-                        "By",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.memory.used_after_last_gc",
+                "Measure of memory used, as measured after the most recent garbage collection event on this pool.",
+                "By",
+                MetricDataType.LONG_SUM.toString());
     }
 
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmThreadTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmThreadTest.java
@@ -23,12 +23,12 @@ package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -44,14 +44,15 @@ public class JvmThreadTest extends Arquillian {
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MetricsReader.class)
+                .addAsLibrary(TestLibraries.AWAITILITY_LIB)
+                .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test
     void testThreadCountMetric() throws IOException {
-        Assert.assertTrue(
-                MetricsReader.checkMessage("jvm.thread.count", "Number of executing platform threads.", "{thread}",
-                        MetricDataType.LONG_SUM.toString()));
+        MetricsReader.assertLogMessage("jvm.thread.count", "Number of executing platform threads.", "{thread}",
+                MetricDataType.LONG_SUM.toString());
     }
 
 }

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/MetricsReader.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/MetricsReader.java
@@ -21,36 +21,87 @@
  **********************************************************************/
 package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.commons.io.input.Tailer;
+import org.apache.commons.io.input.TailerListenerAdapter;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
 
 public class MetricsReader {
 
     private static final String logFilePath = System.getProperty("mptelemetry.tck.log.file.path");
 
-    public static boolean checkMessage(String metricName, String metricDescription, String metricUnit,
-            String metricType)
-            throws IOException {
-        try {
-            Thread.sleep(5000);
-            try {
-                BufferedReader reader = new BufferedReader(new FileReader(logFilePath));
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (line.contains(
-                            "name=" + metricName + ", description=" + metricDescription + ", unit=" + metricUnit
-                                    + ", type=" + metricType)) {
+    /**
+     * This method asserts that a log line matching the following format
+     *
+     * "name=<metricName>, description=<metricDescription>, unit=<metricUnit>, type=<metricType>"
+     *
+     * Can be found in the log file pointed to by the system property mptelemetry.tck.log.file.path. It will wait for up
+     * to fifteen seconds for the log to appear.
+     *
+     * @param metricName
+     *            The name of the metric we expect to find in the logs
+     * @param metricDescription
+     *            The description of the metric we expect to find in the logs
+     * @param metricUnit
+     *            The unit of the metric we expect to find in the logs
+     * @param metricType
+     *            The type of the metric we expect to find in the logs
+     */
+    public static void assertLogMessage(String metricName, String metricDescription, String metricUnit,
+            String metricType) {
 
-                        return true;
-                    }
-                }
-                return false;
-            } catch (IOException e) {
-                return false;
+        String searchString = "name=" + metricName + ", description=" + metricDescription + ", unit=" + metricUnit
+                + ", type=" + metricType;
+
+        ExecutorService es = Executors.newFixedThreadPool(1);
+
+        LogFileTailerAdaptor logFileTailerAdaptor =
+                new LogFileTailerAdaptor(searchString);
+
+        Tailer tailer = Tailer.builder()
+                .setStartThread(true)
+                .setPath(logFilePath)
+                .setExecutorService(es)
+                .setReOpen(false)
+                .setTailerListener(logFileTailerAdaptor)
+                .setTailFromEnd(false)
+                .get();
+
+        try (tailer) {
+            Awaitility.await().atMost(15, SECONDS)
+                    .untilAsserted(() -> Assert.assertTrue(logFileTailerAdaptor.foundMetric(),
+                            "Did not find " + searchString + " in logfile: " + logFilePath));
+        }
+    }
+
+    private static class LogFileTailerAdaptor extends TailerListenerAdapter {
+
+        private final String searchString;
+        private boolean foundMetric = false;
+        private Tailer tailer = null;
+
+        public LogFileTailerAdaptor(String searchString) {
+            this.searchString = searchString;
+        }
+
+        public void init(Tailer tailer) {
+            this.tailer = tailer;
+        }
+
+        public void handle(String line) {
+            if (line.contains(searchString)) {
+                foundMetric = true;
+                tailer.close();
             }
-        } catch (InterruptedException e) {
-            return false;
+        }
+
+        public boolean foundMetric() {
+            return foundMetric;
         }
     }
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -59,6 +59,12 @@
                 <artifactId>awaitility</artifactId>
                 <version>${version.awaitility}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${version.commons.io}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
We received reports that the timeout for the JVM tests was too low, so I rewrote the MetricsReader class. Now it uses commons-io to follow the log close to live (polling once a second) and stops when it finds the right metrics. As a result we can safely increase the maximum timeout significantly. 