### PR TITLE
Wait for the garbage collector before testing

### DIFF
--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
@@ -22,6 +22,8 @@
 package org.eclipse.microprofile.telemetry.metrics.tck.jvm;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.microprofile.telemetry.metrics.tck.application.TestLibraries;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -29,6 +31,7 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.api.OpenTelemetry;
@@ -51,8 +54,50 @@ public class JvmGarbageCollectionTest extends Arquillian {
 
     @Test
     void testGarbageCollectionCountMetric() throws IOException {
+        waitForGarbageCollection();
+
         MetricsReader.assertLogMessage("jvm.gc.duration", "Duration of JVM garbage collection actions.", "s",
                 MetricDataType.HISTOGRAM.toString());
+    }
+
+    // returns true if the GC was invoked, otherwise false;
+    private void waitForGarbageCollection() {
+        long startTime = System.nanoTime();
+
+        // This unusual bit of code is to give the gc something to clean up, with methods
+        // We can call so the JIT cannot short circuit.
+        String garbageString = new String("garbage");
+        WeakReference<String> weakRef = new WeakReference<String>(garbageString);
+        garbageString = null;
+
+        for (int i = 0; i < 10; ++i) {
+            System.gc();
+            // give the GC some time to actually do its thing
+
+            String fromWeakRef = weakRef.get();
+
+            // If our WeakReference returned null we know the garbage collector has acted
+            if (fromWeakRef == null) {
+                return;
+            } else {
+                // Do something with the weak string to be absolutely sure
+                // The JIT doesn't optimise it away
+                String alsoIgnored = fromWeakRef.strip();
+            }
+            
+            try {
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+        }
+        
+        long stopTime = System.nanoTime();
+        long seconds = TimeUnit.SECONDS.toSeconds(stopTime - startTime);
+
+        Assert.fail("The garbage collector did not run after " + seconds + "seconds");
+
     }
 
 }


### PR DESCRIPTION
Resolves #225

This adds a loop that repeatedly calls `System.gc` and only terminates once it has detected that the GC has collected. (Or timesout and fails the test if it takes too long) 