### PR TITLE
Make JVM metrics properly configure themselves

### DIFF
--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmClassesTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmClassesTest.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -46,6 +47,10 @@ public class JvmClassesTest extends Arquillian {
                 .addClasses(MetricsReader.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.metrics.exporter=logging\notel.logs.exporter=none\notel.traces.exporter=none\notel.metric.export.interval=3000"),
+                        "META-INF/microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmCpuTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmCpuTest.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -46,6 +47,10 @@ public class JvmCpuTest extends Arquillian {
                 .addClasses(MetricsReader.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.metrics.exporter=logging\notel.logs.exporter=none\notel.traces.exporter=none\notel.metric.export.interval=3000"),
+                        "META-INF/microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmGarbageCollectionTest.java
@@ -30,6 +30,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -49,6 +50,10 @@ public class JvmGarbageCollectionTest extends Arquillian {
                 .addClasses(MetricsReader.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.metrics.exporter=logging\notel.logs.exporter=none\notel.traces.exporter=none\notel.metric.export.interval=3000"),
+                        "META-INF/microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmMemoryTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmMemoryTest.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -46,6 +47,10 @@ public class JvmMemoryTest extends Arquillian {
                 .addClasses(MetricsReader.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.metrics.exporter=logging\notel.logs.exporter=none\notel.traces.exporter=none\notel.metric.export.interval=3000"),
+                        "META-INF/microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmThreadTest.java
+++ b/tck/metrics/src/main/java/org/eclipse/microprofile/telemetry/metrics/tck/jvm/JvmThreadTest.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -46,6 +47,10 @@ public class JvmThreadTest extends Arquillian {
                 .addClasses(MetricsReader.class)
                 .addAsLibrary(TestLibraries.AWAITILITY_LIB)
                 .addAsLibrary(TestLibraries.COMMONS_IO_LIB)
+                .addAsResource(
+                        new StringAsset(
+                                "otel.sdk.disabled=false\notel.metrics.exporter=logging\notel.logs.exporter=none\notel.traces.exporter=none\notel.metric.export.interval=3000"),
+                        "META-INF/microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 


### PR DESCRIPTION
The JVM metrics tests are the only tests that don't properly configure themselves. This change adds this configuration usin MP Config like the other tests do, thus allowing the entire TCK to be run in a single surefire execution, with the only external configuration required being the log file location.