### PR TITLE
Update the OTel dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
 
     <properties>
         <inceptionYear>2022</inceptionYear>
-        <opentelemetry.java.version>1.49.0</opentelemetry.java.version>
-        <opentelemetry.semconv.version>1.32.0</opentelemetry.semconv.version>
-        <opentelemetry.java.instrumentation.version>2.15.0</opentelemetry.java.instrumentation.version>
+        <opentelemetry.java.version>1.60.1</opentelemetry.java.version>
+        <opentelemetry.semconv.version>1.40.0</opentelemetry.semconv.version>
+        <opentelemetry.java.instrumentation.version>2.26.0</opentelemetry.java.instrumentation.version>
         <version.mp.rest.client>4.0</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.3.0</version.awaitility>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.3.0</version.awaitility>
         <!-- Telemetry refers only to Semantic Conversion specification, java artifact is only used in TCK -->
-        <version.otel.semconv-java>1.32.0</version.otel.semconv-java>
+        <version.otel.semconv-java>1.40.0</version.otel.semconv-java>
         <version.mp.parent>3.4</version.mp.parent>
         <version.commons.io>2.21.0</version.commons.io>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <inceptionYear>2022</inceptionYear>
         <opentelemetry.java.version>1.60.1</opentelemetry.java.version>
         <opentelemetry.semconv.version>1.40.0</opentelemetry.semconv.version>
-        <opentelemetry.java.instrumentation.version>2.26.0</opentelemetry.java.instrumentation.version>
+        <opentelemetry.java.instrumentation.version>2.26.1</opentelemetry.java.instrumentation.version>
         <version.mp.rest.client>4.0</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.3.0</version.awaitility>


### PR DESCRIPTION
Update to use the latest OTel release:
1. https://github.com/open-telemetry/opentelemetry-java/compare/v1.49.0...v1..60.x


The upgrade from OpenTelemetry Java v1.49 to v1.60 appears to be backward compatible from an API perspective, as evidenced by:

- No code changes required in the MicroProfile Telemetry TCK tests
- No breaking changes documented in the MicroProfile Telemetry release notes (though 2.2 notes are pending)
- All existing APIs continue to work without modification
- The changes between v1.49 and v1.60 likely include:
- Bug fixes and performance improvements
- Internal implementation enhancements
- Possible new features (additive, not breaking)
- Dependency updates
- Minor API additions (non-breaking)

2. https://github.com/open-telemetry/semantic-conventions-java/compare/v1.32.0...v1.40.0

 Semantic conventions updates typically include:
- New Attributes: Addition of new semantic convention attributes for various telemetry signals
- Deprecated Attributes: Marking old attributes as deprecated (especially HTTP-related ones)
- Stabilized Conventions: Moving conventions from experimental to stable status
- Updated Definitions: Refinements to attribute definitions and requirements
- New Domains: Addition of semantic conventions for new technology domains
- Requirement Level Changes: Updates to whether attributes are required, recommended, or optional
- Impact on Applications
- The semantic conventions library (opentelemetry-semconv) provides:

     - Constants for attribute keys
     - Constants for attribute values
     - Helper methods for creating attributes

- Changes between v1.32.0 and v1.40.0 would primarily affect:

    - Code using HTTP-related semantic convention constants (major changes)
    - Code using newly added or deprecated attribute constants
     - Applications needing to comply with updated semantic convention requirements



3. https://github.com/open-telemetry/opentelemetry-java-instrumentation/compare/v2.15.0...v2.26.1
Based on the code analysis, the upgrade from v2.15.0 to v2.26.1 appears to be backward compatible for the annotations API:

- No code changes required in the MicroProfile Telemetry TCK
- @WithSpan and @SpanAttribute continue to work as before
- The annotations API is stable and well-maintained