### PR TITLE
Update otel version to 1.63.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,14 @@
 
     <properties>
         <inceptionYear>2022</inceptionYear>
-        <opentelemetry.java.version>1.60.1</opentelemetry.java.version>
-        <opentelemetry.semconv.version>1.40.0</opentelemetry.semconv.version>
-        <opentelemetry.java.instrumentation.version>2.26.1</opentelemetry.java.instrumentation.version>
+        <opentelemetry.java.version>1.63.0</opentelemetry.java.version>
+        <opentelemetry.semconv.version>1.41.1</opentelemetry.semconv.version>
+        <opentelemetry.java.instrumentation.version>2.28.1</opentelemetry.java.instrumentation.version>
         <version.mp.rest.client>4.0</version.mp.rest.client>
         <version.microprofile-config-api>3.1</version.microprofile-config-api>
         <version.awaitility>4.3.0</version.awaitility>
         <!-- Telemetry refers only to Semantic Conversion specification, java artifact is only used in TCK -->
-        <version.otel.semconv-java>1.40.0</version.otel.semconv-java>
+        <version.otel.semconv-java>1.41.1</version.otel.semconv-java>
         <version.mp.parent>3.4</version.mp.parent>
         <version.commons.io>2.21.0</version.commons.io>
     </properties>


### PR DESCRIPTION
Updates three dependency properties in [pom.xml](https://github.com/Yas-Franco/microprofile-telemetry/blob/version-1.63/pom.xml)

OpenTelemetry Java: 1.60.1 → 1.63.0
Semantic Conventions: 1.40.0 → 1.41.1
OpenTelemetry Java Instrumentation: 2.26.1 → 2.28.1
Summary of the version differences based on the upstream release pages:

OpenTelemetry Java 1.63.0 adds API/SDK improvements and fixes, including new [setAttribute](vscode-webview://1lfma2crl8h7oerntcathi4jitqfh9et72nbq8vd55q1kocuuuso/Span) and [setAttribute](vscode-webview://1lfma2crl8h7oerntcathi4jitqfh9et72nbq8vd55q1kocuuuso/LogRecordBuilder) shortcuts, metrics/exemplar updates, exporter fixes, and at least one breaking cleanup around deprecated extended attributes.
Semantic Conventions 1.41.1 is a very small update from 1.40.0; the visible release note for 1.41.1 shows a targeted change excluding certain Kubernetes CPU utilization metrics from code generation.
OpenTelemetry Java Instrumentation 2.28.1 brings newer instrumentation libraries and bug fixes; the release notes indicate it targets OpenTelemetry SDK 1.62.0 and includes bug-fix-focused updates in that release line.

See: 
- https://github.com/open-telemetry/opentelemetry-java/releases
- https://github.com/open-telemetry/semantic-conventions/releases
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases